### PR TITLE
RHOAIENG-32022: Add OpenShift OAuth provider support kube-oauth-proxy 

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -340,6 +340,7 @@ Provider holds all configuration for a single provider
 | `allowedGroups` | _[]string_ | AllowedGroups is a list of restrict logins to members of this group |
 | `code_challenge_method` | _string_ | The code challenge method |
 | `backendLogoutURL` | _string_ | URL to call to perform backend logout, `{id_token}` would be replaced by the actual `id_token` if available in the session |
+| `serviceAccount` | _string_ | OpenShift-specific options<br/>ServiceAccount is the name of the OpenShift service account to use for auto-detecting OAuth client credentials |
 
 ### ProviderType
 #### (`string` alias)

--- a/examples/oidc/config.yaml
+++ b/examples/oidc/config.yaml
@@ -1,0 +1,55 @@
+# OIDC Configuration for kube-auth-proxy
+# Replace placeholder values with your actual OIDC provider details
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-auth-proxy-config
+  namespace: default
+data:
+  # OIDC Provider Configuration
+  provider: "oidc"
+  
+  # OIDC Provider URLs - replace with your provider's URLs
+  oidc-issuer-url: "https://your-oidc-provider.example.com/realms/your-realm"
+  
+  # Client Configuration - replace with your client ID
+  client-id: "your-client-id"
+  
+  # OAuth2 Scopes
+  scope: "openid email profile"
+  
+  # Proxy Settings
+  http-address: "0.0.0.0:4180"
+  upstreams: "http://example-app:8080"
+  
+  # Email domains (configure as needed)
+  email-domains: "*"
+  
+  # Redirect URI configuration - replace with your domain
+  redirect-url: "https://your-app.example.com/oauth2/callback"
+  
+  # OIDC Token Claims
+  oidc-groups-claim: "groups"
+  oidc-email-claim: "email"
+  
+  # Header forwarding
+  pass-basic-auth: "false"
+  pass-access-token: "true"
+  pass-user-headers: "true"
+  pass-host-header: "true"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-auth-proxy-secret
+  namespace: default
+type: Opaque
+stringData:
+  # Replace with your actual client secret
+  client-secret: "your-client-secret"
+  
+  # Generate a random 32-byte base64-encoded string for cookie encryption
+  # Example: openssl rand -base64 32
+  cookie-secret: "REPLACE-WITH-BASE64-ENCODED-SECRET"

--- a/examples/oidc/deployment.yaml
+++ b/examples/oidc/deployment.yaml
@@ -1,0 +1,193 @@
+# kube-auth-proxy OIDC Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-auth-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-auth-proxy
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+      - name: kube-auth-proxy
+        image: quay.io/opendatahub/kube-auth-proxy:<version-or-digest>
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        ports:
+        - containerPort: 4180
+          name: http
+        env:
+        - name: OAUTH2_PROXY_PROVIDER
+          valueFrom:
+            configMapKeyRef:
+              key: provider
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_OIDC_ISSUER_URL
+          valueFrom:
+            configMapKeyRef:
+              key: oidc-issuer-url
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              key: client-id
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: client-secret
+              name: kube-auth-proxy-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: cookie-secret
+              name: kube-auth-proxy-secret
+        - name: OAUTH2_PROXY_SCOPE
+          valueFrom:
+            configMapKeyRef:
+              key: scope
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_HTTP_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              key: http-address
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_UPSTREAMS
+          valueFrom:
+            configMapKeyRef:
+              key: upstreams
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_EMAIL_DOMAINS
+          valueFrom:
+            configMapKeyRef:
+              key: email-domains
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_REDIRECT_URL
+          valueFrom:
+            configMapKeyRef:
+              key: redirect-url
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_OIDC_GROUPS_CLAIM
+          valueFrom:
+            configMapKeyRef:
+              key: oidc-groups-claim
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_OIDC_EMAIL_CLAIM
+          valueFrom:
+            configMapKeyRef:
+              key: oidc-email-claim
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_BASIC_AUTH
+          valueFrom:
+            configMapKeyRef:
+              key: pass-basic-auth
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_ACCESS_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              key: pass-access-token
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_USER_HEADERS
+          valueFrom:
+            configMapKeyRef:
+              key: pass-user-headers
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_HOST_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: pass-host-header
+              name: kube-auth-proxy-config
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  selector:
+    app: kube-auth-proxy
+  ports:
+  - name: http
+    port: 80
+    targetPort: 4180
+
+---
+# Example upstream application for testing
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: default
+  labels:
+    app: example-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-app
+  template:
+    metadata:
+      labels:
+        app: example-app
+    spec:
+      containers:
+      - name: example-app
+        image: hashicorp/http-echo:latest
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        args:
+        - -text=Hello from authenticated app!
+        - -listen=:8080
+        ports:
+        - containerPort: 8080
+          name: http
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-app
+  namespace: default
+  labels:
+    app: example-app
+spec:
+  selector:
+    app: example-app
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -1,0 +1,135 @@
+# OpenShift OAuth Provider
+
+The OpenShift provider enables `kube-auth-proxy` to authenticate users against OpenShift's built-in OAuth service.
+
+## Basic Usage
+
+### Service Account Auto-Detection (Recommended)
+
+When running inside OpenShift, the proxy can automatically detect OAuth credentials:
+
+```bash
+kube-auth-proxy \
+  --provider=openshift \
+  --openshift-service-account=my-service-account \
+  --upstream=http://my-app:8080 \
+  --http-address=0.0.0.0:4180
+```
+
+**Prerequisites:**
+- Service account must exist in the namespace
+- Service account must have the OAuth redirect URI annotation:
+  ```yaml
+  serviceaccounts.openshift.io/oauth-redirecturi.auth: "https://my-app.apps.cluster.com/oauth2/callback"
+  ```
+
+### Manual Configuration
+
+```bash
+kube-auth-proxy \
+  --provider=openshift \
+  --login-url=https://oauth-openshift.apps.cluster.com/oauth/authorize \
+  --redeem-url=https://oauth-openshift.apps.cluster.com/oauth/token \
+  --validate-url=https://api.cluster.com:6443/apis/user.openshift.io/v1/users/~ \
+  --client-id=system:serviceaccount:my-namespace:my-sa \
+  --client-secret=sha256~abc123... \
+  --upstream=http://my-app:8080 \
+  --http-address=0.0.0.0:4180
+```
+
+## Configuration Options
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `--provider=openshift` | Use OpenShift OAuth provider | ✅ |
+| `--openshift-service-account` | Service account name for auto-detection | For auto-detection |
+| `--upstream` | Backend application URL | ✅ |
+| `--http-address` | Proxy listen address | ✅ |
+
+## Custom CA Certificates
+
+For clusters with custom Certificate Authorities, you can specify CA certificate files:
+
+```bash
+kube-auth-proxy \
+  --provider=openshift \
+  --openshift-service-account=my-service-account \
+  --provider-ca-file=/etc/ssl/certs/custom-ca.crt \
+  --upstream=http://my-app:8080 \
+  --http-address=0.0.0.0:4180
+```
+
+### oauth-proxy Compatibility
+
+For compatibility with existing `oauth-proxy` configurations, the deprecated `--openshift-ca` flag is also supported:
+
+```bash
+# This works but is deprecated - use --provider-ca-file instead
+kube-auth-proxy \
+  --provider=openshift \
+  --openshift-service-account=my-service-account \
+  --openshift-ca=/etc/ssl/certs/custom-ca.crt \
+  --upstream=http://my-app:8080 \
+  --http-address=0.0.0.0:4180
+```
+
+**Migration note**: Both flags can be used together, and their values will be merged. However, `--openshift-ca` is deprecated and will be removed in a future version.
+
+## Multiple Upstreams
+
+The proxy supports routing to multiple backend services:
+
+```bash
+kube-auth-proxy \
+  --provider=openshift \
+  --openshift-service-account=my-service-account \
+  --upstream=http://frontend:3000/ \
+  --upstream=http://api:8080/api/ \
+  --http-address=0.0.0.0:4180
+```
+
+## Simple Deployment Example
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: auth-proxy
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirecturi.auth: "https://my-app.apps.cluster.com/oauth2/callback"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      serviceAccountName: auth-proxy
+      containers:
+      - name: app
+        image: my-app:latest
+        ports:
+        - containerPort: 8080
+      - name: auth-proxy
+        image: kube-auth-proxy:latest
+        args:
+        - --provider=openshift
+        - --openshift-service-account=auth-proxy
+        - --upstream=http://localhost:8080
+        - --http-address=0.0.0.0:4180
+        ports:
+        - containerPort: 4180
+```
+---
+
+> **Note**: This documentation covers basic, tested functionality. Additional features and deployment patterns will be documented as they are implemented and validated.
+
+For more information, see the [main documentation](../../README.md).

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -1,135 +1,61 @@
 # OpenShift OAuth Provider
 
-The OpenShift provider enables `kube-auth-proxy` to authenticate users against OpenShift's built-in OAuth service.
+The OpenShift provider enables `kube-auth-proxy` to authenticate users against OpenShift's built-in OAuth service, providing seamless integration with OpenShift's RBAC and user management.
 
-## Basic Usage
+## Two Approaches Available
 
-### Service Account Auto-Detection (Recommended)
+### [Manual OAuth Client](manual/)
+**Best for**: Full control, traditional OAuth setup, custom client settings
+- You create and manage the `OAuthClient` resource
+- Client ID matches the OAuth client resource name  
+- You manage client secrets manually
+- More control over OAuth client configuration
 
-When running inside OpenShift, the proxy can automatically detect OAuth credentials:
+### [Service Account Auto-Detection](service-account/)  
+**Best for**: Simple deployment, automatic management, RBAC integration
+- Service account acts as the OAuth client (no separate OAuthClient resource)
+- Client ID is `system:serviceaccount:<namespace>:<service-account>`
+- Service account token used as client secret
+- Zero OAuth client management needed
 
-```bash
-kube-auth-proxy \
-  --provider=openshift \
-  --openshift-service-account=my-service-account \
-  --upstream=http://my-app:8080 \
-  --http-address=0.0.0.0:4180
-```
+## Common Features
 
-**Prerequisites:**
-- Service account must exist in the namespace
-- Service account must have the OAuth redirect URI annotation:
-  ```yaml
-  serviceaccounts.openshift.io/oauth-redirecturi.auth: "https://my-app.apps.cluster.com/oauth2/callback"
-  ```
+Both approaches provide:
+- **Native OpenShift Integration**: Uses OpenShift's built-in OAuth server
+- **Access Token Forwarding**: Forwards OAuth tokens for downstream Kubernetes API calls  
+- **TLS Certificate Management**: Handles OpenShift's internal CA certificates automatically
+- **User Information**: Forwards user identity and email to upstream applications
 
-### Manual Configuration
+## Quick Comparison
 
-```bash
-kube-auth-proxy \
-  --provider=openshift \
-  --login-url=https://oauth-openshift.apps.cluster.com/oauth/authorize \
-  --redeem-url=https://oauth-openshift.apps.cluster.com/oauth/token \
-  --validate-url=https://api.cluster.com:6443/apis/user.openshift.io/v1/users/~ \
-  --client-id=system:serviceaccount:my-namespace:my-sa \
-  --client-secret=sha256~abc123... \
-  --upstream=http://my-app:8080 \
-  --http-address=0.0.0.0:4180
-```
+| Feature | Manual OAuth Client | Service Account Auto-Detection |
+|---------|--------------------|---------------------------------|
+| **Setup Complexity** | Medium (create OAuth client) | Low (just deploy) |
+| **OAuth Client Management** | Manual | None (service account is the client) |
+| **Client ID Format** | Your choice | `system:serviceaccount:*` |
+| **Secret Management** | Manual | Automatic (service account token) |
+| **Customization** | High | Limited |
+| **RBAC Integration** | Manual setup | Automatic |
 
-## Configuration Options
+## Access Token Forwarding
 
-| Option | Description | Required |
-|--------|-------------|----------|
-| `--provider=openshift` | Use OpenShift OAuth provider | ✅ |
-| `--openshift-service-account` | Service account name for auto-detection | For auto-detection |
-| `--upstream` | Backend application URL | ✅ |
-| `--http-address` | Proxy listen address | ✅ |
+Both approaches forward authentication information to upstream applications:
 
-## Custom CA Certificates
+### Headers Forwarded to Upstream
+- `X-Forwarded-Access-Token`: OAuth access token for Kubernetes API calls
+- `X-Forwarded-User`: Authenticated username from OpenShift
+- `X-Forwarded-Email`: User email address (or generated from username)
 
-For clusters with custom Certificate Authorities, you can specify CA certificate files:
+### Using Tokens for Kubernetes API Access
 
-```bash
-kube-auth-proxy \
-  --provider=openshift \
-  --openshift-service-account=my-service-account \
-  --provider-ca-file=/etc/ssl/certs/custom-ca.crt \
-  --upstream=http://my-app:8080 \
-  --http-address=0.0.0.0:4180
-```
-
-### oauth-proxy Compatibility
-
-For compatibility with existing `oauth-proxy` configurations, the deprecated `--openshift-ca` flag is also supported:
+Your upstream applications can use the forwarded token to make authenticated Kubernetes API calls:
 
 ```bash
-# This works but is deprecated - use --provider-ca-file instead
-kube-auth-proxy \
-  --provider=openshift \
-  --openshift-service-account=my-service-account \
-  --openshift-ca=/etc/ssl/certs/custom-ca.crt \
-  --upstream=http://my-app:8080 \
-  --http-address=0.0.0.0:4180
+# Example: Get user information
+curl -H "Authorization: Bearer $X_FORWARDED_ACCESS_TOKEN" \
+     https://api.cluster.example.com/apis/user.openshift.io/v1/users/~
+
+# Example: List accessible projects  
+curl -H "Authorization: Bearer $X_FORWARDED_ACCESS_TOKEN" \
+     https://api.cluster.example.com/apis/project.openshift.io/v1/projects
 ```
-
-**Migration note**: Both flags can be used together, and their values will be merged. However, `--openshift-ca` is deprecated and will be removed in a future version.
-
-## Multiple Upstreams
-
-The proxy supports routing to multiple backend services:
-
-```bash
-kube-auth-proxy \
-  --provider=openshift \
-  --openshift-service-account=my-service-account \
-  --upstream=http://frontend:3000/ \
-  --upstream=http://api:8080/api/ \
-  --http-address=0.0.0.0:4180
-```
-
-## Simple Deployment Example
-
-```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: auth-proxy
-  annotations:
-    serviceaccounts.openshift.io/oauth-redirecturi.auth: "https://my-app.apps.cluster.com/oauth2/callback"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-app
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: my-app
-  template:
-    metadata:
-      labels:
-        app: my-app
-    spec:
-      serviceAccountName: auth-proxy
-      containers:
-      - name: app
-        image: my-app:latest
-        ports:
-        - containerPort: 8080
-      - name: auth-proxy
-        image: kube-auth-proxy:latest
-        args:
-        - --provider=openshift
-        - --openshift-service-account=auth-proxy
-        - --upstream=http://localhost:8080
-        - --http-address=0.0.0.0:4180
-        ports:
-        - containerPort: 4180
-```
----
-
-> **Note**: This documentation covers basic, tested functionality. Additional features and deployment patterns will be documented as they are implemented and validated.
-
-For more information, see the [main documentation](../../README.md).

--- a/examples/openshift/manual/config.yaml
+++ b/examples/openshift/manual/config.yaml
@@ -1,0 +1,53 @@
+# OpenShift OAuth Configuration - Manual OAuth Client Approach
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-auth-proxy-config
+  namespace: default
+data:
+  # OpenShift OAuth Provider
+  provider: "openshift"
+  
+  # OAuth Client ID - must match the OAuthClient resource name exactly
+  client-id: "kube-auth-proxy"
+  
+  # Proxy Settings
+  http-address: "0.0.0.0:4180"
+  upstreams: "http://example-app:8080"
+  
+  # Email domains (configure as needed)
+  email-domains: "*"
+  
+  # Redirect URI - replace with your actual domain
+  redirect-url: "https://your-app.apps.cluster.example.com/oauth2/callback"
+  
+  # OpenShift OAuth scope
+  scope: "user:info"
+  
+  # Header forwarding
+  pass-basic-auth: "false"
+  pass-access-token: "true"
+  pass-user-headers: "true"
+  pass-host-header: "true"
+  
+  # Session settings
+  cookie-expire: "1h"
+  cookie-refresh: "30m"
+  
+  # TLS Configuration - uses automatic service account CA
+  use-system-trust-store: "true"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-auth-proxy-secret
+  namespace: default
+type: Opaque
+stringData:
+  # Must match the secret in the OAuthClient resource
+  client-secret: "REPLACE-WITH-BASE64-ENCODED-SECRET"
+  
+  # Generate a random 32-byte base64-encoded string for cookie encryption
+  # Example: openssl rand -base64 32
+  cookie-secret: "REPLACE-WITH-BASE64-ENCODED-32-BYTE-SECRET"

--- a/examples/openshift/manual/deployment.yaml
+++ b/examples/openshift/manual/deployment.yaml
@@ -1,0 +1,220 @@
+# kube-auth-proxy OpenShift OAuth Deployment - Manual OAuth Client
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-auth-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-auth-proxy
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kube-auth-proxy
+      containers:
+      - name: kube-auth-proxy
+        image: quay.io/opendatahub/kube-auth-proxy:<version-or-digest>
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        ports:
+        - containerPort: 4180
+          name: http
+        env:
+        - name: OAUTH2_PROXY_PROVIDER
+          valueFrom:
+            configMapKeyRef:
+              key: provider
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              key: client-id
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: client-secret
+              name: kube-auth-proxy-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: cookie-secret
+              name: kube-auth-proxy-secret
+        - name: OAUTH2_PROXY_HTTP_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              key: http-address
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_UPSTREAMS
+          valueFrom:
+            configMapKeyRef:
+              key: upstreams
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_EMAIL_DOMAINS
+          valueFrom:
+            configMapKeyRef:
+              key: email-domains
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_REDIRECT_URL
+          valueFrom:
+            configMapKeyRef:
+              key: redirect-url
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_SCOPE
+          valueFrom:
+            configMapKeyRef:
+              key: scope
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_BASIC_AUTH
+          valueFrom:
+            configMapKeyRef:
+              key: pass-basic-auth
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_ACCESS_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              key: pass-access-token
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_USER_HEADERS
+          valueFrom:
+            configMapKeyRef:
+              key: pass-user-headers
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_HOST_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: pass-host-header
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_COOKIE_EXPIRE
+          valueFrom:
+            configMapKeyRef:
+              key: cookie-expire
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_COOKIE_REFRESH
+          valueFrom:
+            configMapKeyRef:
+              key: cookie-refresh
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_USE_SYSTEM_TRUST_STORE
+          valueFrom:
+            configMapKeyRef:
+              key: use-system-trust-store
+              name: kube-auth-proxy-config
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  selector:
+    app: kube-auth-proxy
+  ports:
+  - name: http
+    port: 80
+    targetPort: 4180
+
+---
+# Service account for running the proxy (not used for OAuth auto-detection in manual approach)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+
+---
+# Example upstream application for testing
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: default
+  labels:
+    app: example-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-app
+  template:
+    metadata:
+      labels:
+        app: example-app
+    spec:
+      containers:
+      - name: example-app
+        image: hashicorp/http-echo:latest
+        args:
+        - -text=Hello from OpenShift authenticated app!
+        - -listen=:8080
+        ports:
+        - containerPort: 8080
+          name: http
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-app
+  namespace: default
+  labels:
+    app: example-app
+spec:
+  selector:
+    app: example-app
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+
+---
+# OpenShift Route to expose the application
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  # Replace with your desired hostname
+  host: your-app.apps.cluster.example.com
+  to:
+    kind: Service
+    name: kube-auth-proxy
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/examples/openshift/manual/oauth-client.yaml
+++ b/examples/openshift/manual/oauth-client.yaml
@@ -1,0 +1,13 @@
+# OpenShift OAuth Client Configuration - Manual Approach
+# This registers your application with OpenShift's OAuth server
+# The client-id in your config must match metadata.name exactly
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: kube-auth-proxy  # ← This becomes your client-id
+grantMethod: auto
+redirectURIs:
+# Replace with your actual application domain
+- "https://your-app.apps.cluster.example.com/oauth2/callback"
+# Generate a secure random secret and use the same value in config.yaml
+secret: "REPLACE-WITH-SECURE-RANDOM-SECRET"

--- a/examples/openshift/service-account/config.yaml
+++ b/examples/openshift/service-account/config.yaml
@@ -1,0 +1,57 @@
+# OpenShift OAuth Configuration for kube-auth-proxy
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-auth-proxy-config
+  namespace: default
+data:
+  # OpenShift OAuth Provider
+  provider: "openshift"
+  
+  # OAuth Client ID - auto-generated from service account when using auto-detection
+  # Format: system:serviceaccount:<namespace>:<service-account-name>
+  client-id: "system:serviceaccount:default:kube-auth-proxy"
+  
+  # Service account for auto-detection
+  openshift-service-account: "kube-auth-proxy"
+  
+  # Client secret file - points to service account token
+  client-secret-file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  
+  # Proxy Settings
+  http-address: "0.0.0.0:4180"
+  upstreams: "http://example-app:8080"
+  
+  # Email domains (configure as needed)
+  email-domains: "*"
+  
+  # Redirect URI - replace with your actual domain
+  redirect-url: "https://your-app.apps.cluster.example.com/oauth2/callback"
+  
+  # OpenShift OAuth scope
+  scope: "user:info"
+  
+  # Header forwarding
+  pass-basic-auth: "false"
+  pass-access-token: "true"
+  pass-user-headers: "true"
+  pass-host-header: "true"
+  
+  # Session settings
+  cookie-expire: "1h"
+  cookie-refresh: "30m"
+  
+  # TLS Configuration - uses automatic service account CA
+  use-system-trust-store: "true"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-auth-proxy-secret
+  namespace: default
+type: Opaque
+stringData:
+  # Generate a random 32-byte base64-encoded string for cookie encryption
+  # Example: openssl rand -base64 32
+  cookie-secret: "REPLACE-WITH-BASE64-ENCODED-32-BYTE-SECRET"

--- a/examples/openshift/service-account/deployment.yaml
+++ b/examples/openshift/service-account/deployment.yaml
@@ -1,0 +1,225 @@
+# kube-auth-proxy OpenShift OAuth Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-auth-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-auth-proxy
+    spec:
+      serviceAccountName: kube-auth-proxy
+      containers:
+      - name: kube-auth-proxy
+        image: quay.io/opendatahub/kube-auth-proxy:<version-or-digest>
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        ports:
+        - containerPort: 4180
+          name: http
+        env:
+        - name: OAUTH2_PROXY_PROVIDER
+          valueFrom:
+            configMapKeyRef:
+              key: provider
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              key: client-id
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_CLIENT_SECRET_FILE
+          valueFrom:
+            configMapKeyRef:
+              key: client-secret-file
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_OPENSHIFT_SERVICE_ACCOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-service-account
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: cookie-secret
+              name: kube-auth-proxy-secret
+        - name: OAUTH2_PROXY_HTTP_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              key: http-address
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_UPSTREAMS
+          valueFrom:
+            configMapKeyRef:
+              key: upstreams
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_EMAIL_DOMAINS
+          valueFrom:
+            configMapKeyRef:
+              key: email-domains
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_REDIRECT_URL
+          valueFrom:
+            configMapKeyRef:
+              key: redirect-url
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_SCOPE
+          valueFrom:
+            configMapKeyRef:
+              key: scope
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_BASIC_AUTH
+          valueFrom:
+            configMapKeyRef:
+              key: pass-basic-auth
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_ACCESS_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              key: pass-access-token
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_USER_HEADERS
+          valueFrom:
+            configMapKeyRef:
+              key: pass-user-headers
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_PASS_HOST_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: pass-host-header
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_COOKIE_EXPIRE
+          valueFrom:
+            configMapKeyRef:
+              key: cookie-expire
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_COOKIE_REFRESH
+          valueFrom:
+            configMapKeyRef:
+              key: cookie-refresh
+              name: kube-auth-proxy-config
+        - name: OAUTH2_PROXY_USE_SYSTEM_TRUST_STORE
+          valueFrom:
+            configMapKeyRef:
+              key: use-system-trust-store
+              name: kube-auth-proxy-config
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  selector:
+    app: kube-auth-proxy
+  ports:
+  - name: http
+    port: 80
+    targetPort: 4180
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  annotations:
+    # OAuth redirect URI annotation - replace with your actual domain
+    serviceaccounts.openshift.io/oauth-redirectreference.kube-auth-proxy: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"kube-auth-proxy"}}'
+
+---
+# Example upstream application for testing
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: default
+  labels:
+    app: example-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-app
+  template:
+    metadata:
+      labels:
+        app: example-app
+    spec:
+      containers:
+      - name: example-app
+        image: hashicorp/http-echo:latest
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        args:
+        - -text=Hello from OpenShift authenticated app!
+        - -listen=:8080
+        ports:
+        - containerPort: 8080
+          name: http
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-app
+  namespace: default
+  labels:
+    app: example-app
+spec:
+  selector:
+    app: example-app
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+
+---
+# OpenShift Route to expose the application
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kube-auth-proxy
+  namespace: default
+  labels:
+    app: kube-auth-proxy
+spec:
+  # Replace with your desired hostname
+  host: your-app.apps.cluster.example.com
+  to:
+    kind: Service
+    name: kube-auth-proxy
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -76,6 +76,10 @@ type Provider struct {
 
 	// URL to call to perform backend logout, `{id_token}` would be replaced by the actual `id_token` if available in the session
 	BackendLogoutURL string `json:"backendLogoutURL"`
+
+	// OpenShift-specific options
+	// ServiceAccount is the name of the OpenShift service account to use for auto-detecting OAuth client credentials
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // ProviderType is used to enumerate the different provider type options
@@ -85,6 +89,8 @@ type ProviderType string
 const (
 	// OIDCProvider is the provider type for OIDC
 	OIDCProvider ProviderType = "oidc"
+	// OpenShiftProvider is the provider type for OpenShift OAuth
+	OpenShiftProvider ProviderType = "openshift"
 )
 
 type OIDCOptions struct {

--- a/providers/openshift.go
+++ b/providers/openshift.go
@@ -1,0 +1,506 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bitly/go-simplejson"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+)
+
+const (
+	// openShiftDefaultScope defines the default OAuth scopes for OpenShift authentication
+	// user:info - allows reading user information
+	openShiftDefaultScope = "user:info"
+
+	// Default OpenShift provider name
+	openShiftDefaultName = "OpenShift OAuth"
+
+	// OpenShift API paths
+	openShiftUserInfoPath       = "/apis/user.openshift.io/v1/users/~"
+	openShiftOAuthDiscoveryPath = "/.well-known/oauth-authorization-server"
+
+	// Kubernetes service account paths
+	serviceAccountNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	serviceAccountTokenPath     = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101
+	serviceAccountCAPath        = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+	// Default Kubernetes service DNS name
+	kubernetesDefaultService = "kubernetes.default.svc"
+)
+
+// OpenShiftProvider implements OAuth2 authentication for OpenShift clusters.
+// It supports both manual configuration and automatic service account detection
+// when running inside an OpenShift/Kubernetes cluster.
+type OpenShiftProvider struct {
+	*ProviderData
+	useSystemTrustStore bool
+	discoveryOnce       sync.Once
+	discoveryErr        error
+	discoveredLogin     *url.URL
+	discoveredRedeem    *url.URL
+
+	// CAFiles contains paths to custom CA certificate files for TLS connections
+	// to the OpenShift OAuth server and API endpoints
+	CAFiles []string
+
+	// httpClientCache caches HTTP clients by CA configuration to avoid
+	// recreating clients when CA certificates haven't changed
+	httpClientCache sync.Map
+}
+
+// NewOpenShiftProvider creates a new OpenShiftProvider instance.
+// It configures default OAuth endpoints and handles service account auto-detection
+// if the ServiceAccount option is specified.
+func NewOpenShiftProvider(p *ProviderData, cfg options.Provider) (*OpenShiftProvider, error) {
+	// Determine provider display name
+	name := openShiftDefaultName
+	if p.ProviderName != "" {
+		name = p.ProviderName
+	}
+
+	// Set provider defaults
+	defaults := providerDefaults{
+		name:        name,
+		scope:       openShiftDefaultScope,
+		loginURL:    nil,
+		redeemURL:   nil,
+		validateURL: nil,
+	}
+
+	// Set default validateURL if not already configured
+	if p.ValidateURL == nil || p.ValidateURL.String() == "" {
+		discoveredURL, err := url.Parse(getKubeAPIURLWithPath(openShiftUserInfoPath))
+		if err != nil {
+			return nil, fmt.Errorf("failed to auto-detect validate URL: %v", err)
+		}
+		defaults.validateURL = discoveredURL
+	}
+
+	p.setProviderDefaults(defaults)
+
+	// Auto-detect service account credentials if service account is specified
+	// and no explicit credentials are provided
+	if cfg.ServiceAccount != "" && p.ClientID == "" && p.ClientSecret == "" {
+		clientID, clientSecret := loadServiceAccountDefaults(cfg.ServiceAccount)
+		if clientID != "" {
+			p.ClientID = clientID
+		}
+		if clientSecret != "" {
+			p.ClientSecret = clientSecret
+		}
+	}
+
+	// Use Bearer token for API calls
+	p.getAuthorizationHeaderFunc = makeOIDCHeader
+
+	return &OpenShiftProvider{
+		ProviderData:        p,
+		CAFiles:             cfg.CAFiles,
+		useSystemTrustStore: cfg.UseSystemTrustStore,
+	}, nil
+}
+
+// GetLoginURL returns the OAuth login URL, using discovery if not configured
+func (p *OpenShiftProvider) GetLoginURL(redirectURI, state, _ string, extraParams url.Values) string {
+	// If LoginURL is not configured, try auto-discovery as a convenience
+	if p.LoginURL == nil || p.LoginURL.String() == "" {
+		logger.Printf("LoginURL not configured, attempting auto-discovery from Kubernetes API")
+		client, err := p.newOpenShiftClient()
+		if err != nil {
+			logger.Errorf("Failed to create OpenShift client for discovery: %v", err)
+			logger.Printf("Please configure --login-url manually")
+			return ""
+		}
+		p.discoveryOnce.Do(func() {
+			p.discoveredLogin, p.discoveredRedeem, p.discoveryErr = p.discoverOpenShiftOAuth(client)
+		})
+		if p.discoveryErr != nil || p.discoveredLogin == nil {
+			if p.discoveryErr != nil {
+				logger.Errorf("Failed to discover OpenShift OAuth endpoints: %v", p.discoveryErr)
+			}
+			logger.Printf("Please configure --login-url and --redeem-url manually")
+			return ""
+		}
+		p.LoginURL = p.discoveredLogin
+		if p.RedeemURL == nil || p.RedeemURL.String() == "" {
+			p.RedeemURL = p.discoveredRedeem
+		}
+		logger.Printf("Auto-discovered LoginURL: %s", p.LoginURL.String())
+		if p.RedeemURL != nil {
+			logger.Printf("Auto-discovered RedeemURL: %s", p.RedeemURL.String())
+		}
+	}
+
+	// Build the complete OAuth2 authorization URL using the standard helper
+	loginURL := makeLoginURL(p.Data(), redirectURI, state, extraParams)
+	return loginURL.String()
+}
+
+// Redeem exchanges the authorization code for an access token
+func (p *OpenShiftProvider) Redeem(ctx context.Context, redirectURL, code, codeVerifier string) (*sessions.SessionState, error) {
+	if code == "" {
+		return nil, errors.New("missing code")
+	}
+
+	client, err := p.newOpenShiftClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get redeem URL from discovery if not configured
+	redeemURL := p.RedeemURL
+	if redeemURL == nil || redeemURL.String() == "" {
+		p.discoveryOnce.Do(func() {
+			p.discoveredLogin, p.discoveredRedeem, p.discoveryErr = p.discoverOpenShiftOAuth(client)
+		})
+		if p.discoveryErr != nil || p.discoveredRedeem == nil {
+			return nil, fmt.Errorf("failed to discover redeem URL: %v", p.discoveryErr)
+		}
+		redeemURL = p.discoveredRedeem
+		// Persist for subsequent calls if not explicitly configured
+		if p.RedeemURL == nil || p.RedeemURL.String() == "" {
+			p.RedeemURL = redeemURL
+		}
+	}
+
+	params := url.Values{}
+	params.Add("redirect_uri", redirectURL)
+	params.Add("client_id", p.ClientID)
+	params.Add("client_secret", p.ClientSecret)
+	params.Add("code", code)
+	params.Add("grant_type", "authorization_code")
+	if codeVerifier != "" {
+		params.Add("code_verifier", codeVerifier)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", redeemURL.String(), bytes.NewBufferString(params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("token endpoint %q returned status %d", redeemURL.String(), resp.StatusCode)
+	}
+
+	// Try JSON response first
+	var jsonResponse struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &jsonResponse); err == nil && jsonResponse.AccessToken != "" {
+		return &sessions.SessionState{
+			AccessToken: jsonResponse.AccessToken,
+		}, nil
+	}
+
+	// Try form-encoded response
+	v, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, err
+	}
+	if accessToken := v.Get("access_token"); accessToken != "" {
+		return &sessions.SessionState{
+			AccessToken: accessToken,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no access token found %s", body)
+}
+
+// EnrichSession enriches the session with user information from OpenShift
+func (p *OpenShiftProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+	client, err := p.newOpenShiftClient()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", p.ValidateURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("unable to build request to get user info: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.AccessToken))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve user information: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("got %d %s", resp.StatusCode, body)
+	}
+
+	data, err := simplejson.NewJson(body)
+	if err != nil {
+		return err
+	}
+
+	// Extract user information
+	var userResp struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Email string `json:"email"`
+	}
+
+	if err := json.Unmarshal(body, &userResp); err != nil {
+		return fmt.Errorf("unable to parse user information: %v", err)
+	}
+
+	name := strings.TrimSpace(userResp.Metadata.Name)
+	if name == "" {
+		// Fallback to extracting from JSON
+		name, err = data.Get("metadata").Get("name").String()
+		if err != nil {
+			return fmt.Errorf("user information has no name field: %v", err)
+		}
+	}
+
+	s.User = name
+
+	// Set email using switch for better readability
+	switch {
+	case userResp.Email != "":
+		s.Email = userResp.Email
+	case strings.Contains(name, "@"):
+		s.Email = name
+	default:
+		// Default cluster-local email
+		s.Email = name + "@cluster.local"
+	}
+
+	return nil
+}
+
+// ValidateSession validates the session by checking the user endpoint
+// This method overrides the default validateToken to use our custom HTTP client
+// with proper CA certificate configuration for OpenShift API calls.
+func (p *OpenShiftProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	if s.AccessToken == "" || p.ValidateURL == nil || p.ValidateURL.String() == "" {
+		return false
+	}
+
+	// Use our custom HTTP client with CA certificates
+	client, err := p.newOpenShiftClient()
+	if err != nil {
+		logger.Errorf("failed to create OpenShift client: %v", err)
+		return false
+	}
+
+	// Create request to validate token
+	req, err := http.NewRequestWithContext(ctx, "GET", p.ValidateURL.String(), nil)
+	if err != nil {
+		logger.Errorf("failed to create validation request: %v", err)
+		return false
+	}
+
+	// Add authorization header
+	header := makeOIDCHeader(s.AccessToken)
+	for key, values := range header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	// Perform the request
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Errorf("token validation request failed: %v", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Read response body for logging
+	body, _ := io.ReadAll(resp.Body)
+	logger.Printf("%d GET %s %s", resp.StatusCode, p.ValidateURL.String(), string(body))
+
+	if resp.StatusCode == 200 {
+		return true
+	}
+	logger.Errorf("token validation request failed: status %d - %s", resp.StatusCode, string(body))
+	return false
+}
+
+// newOpenShiftClient returns a client for connecting to the OpenShift OAuth server
+func (p *OpenShiftProvider) newOpenShiftClient() (*http.Client, error) {
+	capaths := p.CAFiles
+	if len(capaths) == 0 {
+		capaths = []string{serviceAccountCAPath}
+	}
+
+	// Simple cache key based on CA paths and system trust store setting
+	cacheKey := fmt.Sprintf("%t:%s", p.useSystemTrustStore, strings.Join(capaths, ","))
+
+	if httpClient, ok := p.httpClientCache.Load(cacheKey); ok {
+		return httpClient.(*http.Client), nil
+	}
+
+	// Create certificate pool
+	var pool *x509.CertPool
+
+	// Load system root CAs if useSystemTrustStore is enabled
+	if p.useSystemTrustStore {
+		if systemPool, err := x509.SystemCertPool(); err == nil {
+			pool = systemPool
+		} else {
+			pool = x509.NewCertPool()
+		}
+	} else {
+		pool = x509.NewCertPool()
+	}
+
+	// Add custom CA certificates
+	for _, caPath := range capaths {
+		if caPEM, err := os.ReadFile(caPath); err == nil {
+			if ok := pool.AppendCertsFromPEM(caPEM); !ok {
+				logger.Errorf("no certs appended from CA file %s", caPath)
+			}
+		} else {
+			logger.Errorf("could not load CA file %s: %v", caPath, err)
+		}
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+				// Use strong security settings
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+		Timeout: 1 * time.Minute,
+	}
+	p.httpClientCache.Store(cacheKey, httpClient)
+
+	return httpClient, nil
+}
+
+// discoverOpenShiftOAuth discovers OAuth endpoints from the well-known endpoint
+func (p *OpenShiftProvider) discoverOpenShiftOAuth(client *http.Client) (*url.URL, *url.URL, error) {
+	wellKnownURL := getKubeAPIURLWithPath(openShiftOAuthDiscoveryPath)
+	logger.Printf("Performing OAuth discovery against %s", wellKnownURL)
+
+	req, err := http.NewRequest("GET", wellKnownURL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, nil, fmt.Errorf("got %d %s", resp.StatusCode, body)
+	}
+
+	data, err := simplejson.NewJson(body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var loginURL, redeemURL *url.URL
+	if value, err := data.Get("authorization_endpoint").String(); err == nil && len(value) > 0 {
+		if loginURL, err = url.Parse(value); err != nil {
+			return nil, nil, fmt.Errorf("unable to parse 'authorization_endpoint' from %s: %v", wellKnownURL, err)
+		}
+	} else {
+		return nil, nil, fmt.Errorf("no 'authorization_endpoint' provided by %s: %v", wellKnownURL, err)
+	}
+
+	if value, err := data.Get("token_endpoint").String(); err == nil && len(value) > 0 {
+		if redeemURL, err = url.Parse(value); err != nil {
+			return nil, nil, fmt.Errorf("unable to parse 'token_endpoint' from %s: %v", wellKnownURL, err)
+		}
+	} else {
+		return nil, nil, fmt.Errorf("no 'token_endpoint' provided by %s: %v", wellKnownURL, err)
+	}
+
+	return loginURL, redeemURL, nil
+}
+
+// getKubeAPIURLWithPath constructs a URL for the Kubernetes API with the given path.
+// It uses environment variables KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
+// for auto-detection when running inside a cluster, falling back to the default
+// Kubernetes service DNS name.
+func getKubeAPIURLWithPath(path string) string {
+	scheme := "https"
+	host := kubernetesDefaultService
+
+	if h := os.Getenv("KUBERNETES_SERVICE_HOST"); len(h) > 0 {
+		// assume IPv6 if host contains colons
+		if strings.IndexByte(h, ':') != -1 {
+			h = "[" + h + "]"
+		}
+		host = h
+	}
+
+	if port := os.Getenv("KUBERNETES_SERVICE_PORT"); len(port) > 0 {
+		host = host + ":" + port
+	}
+
+	return scheme + "://" + host + path
+}
+
+// loadServiceAccountDefaults loads OAuth client defaults from the mounted service account.
+// This function reads the service account namespace and token files that are automatically
+// mounted by Kubernetes when the proxy runs as a pod.
+func loadServiceAccountDefaults(serviceAccount string) (clientID, clientSecret string) {
+	if serviceAccount == "" {
+		return "", ""
+	}
+
+	// Read namespace from mounted service account
+	if data, err := os.ReadFile(serviceAccountNamespacePath); err == nil && len(data) > 0 {
+		namespace := strings.TrimSpace(string(data))
+		clientID = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, serviceAccount)
+		logger.Printf("Auto-detected client-id from service account: %s", clientID)
+	}
+
+	// Read token from mounted service account
+	if data, err := os.ReadFile(serviceAccountTokenPath); err == nil && len(data) > 0 {
+		clientSecret = strings.TrimSpace(string(data))
+		logger.Printf("Auto-detected client-secret from service account token: %s", serviceAccountTokenPath)
+	}
+
+	return clientID, clientSecret
+}

--- a/providers/openshift_test.go
+++ b/providers/openshift_test.go
@@ -1,0 +1,279 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOpenShiftProvider(t *testing.T) {
+	tests := []struct {
+		name                 string
+		providerConfig       options.Provider
+		expectedProviderName string
+		expectedScope        string
+	}{
+		{
+			name: "Default OpenShift provider",
+			providerConfig: options.Provider{
+				Type: options.OpenShiftProvider,
+			},
+			expectedProviderName: "OpenShift OAuth",
+			expectedScope:        openShiftDefaultScope,
+		},
+		{
+			name: "OpenShift provider with custom scope",
+			providerConfig: options.Provider{
+				Type:  options.OpenShiftProvider,
+				Scope: "user:info",
+			},
+			expectedProviderName: "OpenShift OAuth",
+			expectedScope:        "user:info",
+		},
+		{
+			name: "OpenShift provider with service account auto-detection",
+			providerConfig: options.Provider{
+				Type:           options.OpenShiftProvider,
+				ServiceAccount: "my-service-account",
+				// ClientID and ClientSecret intentionally empty to test auto-detection
+			},
+			expectedProviderName: "OpenShift OAuth",
+			expectedScope:        openShiftDefaultScope,
+		},
+		{
+			name: "OpenShift provider with custom display name",
+			providerConfig: options.Provider{
+				Type: options.OpenShiftProvider,
+				Name: "My Custom OpenShift OAuth",
+			},
+			expectedProviderName: "My Custom OpenShift OAuth",
+			expectedScope:        openShiftDefaultScope,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewProvider(tt.providerConfig)
+			assert.NoError(t, err)
+			assert.NotNil(t, provider)
+
+			// Cast to OpenShiftProvider to access the embedded ProviderData
+			openshiftProvider, ok := provider.(*OpenShiftProvider)
+			assert.True(t, ok, "Provider should be an OpenShiftProvider")
+
+			assert.Equal(t, tt.expectedProviderName, openshiftProvider.ProviderData.ProviderName)
+			assert.Equal(t, tt.expectedScope, openshiftProvider.ProviderData.Scope)
+			assert.NotNil(t, openshiftProvider.ValidateURL)
+		})
+	}
+}
+
+func TestOpenShiftProviderGetKubeAPIURLWithPath(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "123")
+
+	tests := []struct {
+		name        string
+		path        string
+		expectedURL string
+	}{
+		{
+			name:        "User info endpoint",
+			path:        "/apis/user.openshift.io/v1/users/~",
+			expectedURL: "https://127.0.0.1:123/apis/user.openshift.io/v1/users/~",
+		},
+		{
+			name:        "OAuth discovery endpoint",
+			path:        "/.well-known/oauth-authorization-server",
+			expectedURL: "https://127.0.0.1:123/.well-known/oauth-authorization-server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getKubeAPIURLWithPath(tt.path)
+			assert.Equal(t, tt.expectedURL, result)
+		})
+	}
+}
+
+func TestOpenShiftProviderRedeem(t *testing.T) {
+	// Mock OAuth server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify that the request contains the expected parameters
+		err := r.ParseForm()
+		require.NoError(t, err)
+
+		assert.Equal(t, "authorization_code", r.FormValue("grant_type"))
+		assert.Equal(t, "test-code", r.FormValue("code"))
+		assert.Equal(t, "test-client-id", r.FormValue("client_id"))
+		assert.Equal(t, "test-client-secret", r.FormValue("client_secret"))
+		assert.Equal(t, "http://localhost/callback", r.FormValue("redirect_uri"))
+
+		// Check if PKCE code_verifier is present
+		codeVerifier := r.FormValue("code_verifier")
+		if codeVerifier != "" {
+			assert.Equal(t, "test-code-verifier", codeVerifier)
+		}
+
+		// Return a successful token response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"access_token": "test-access-token"}`))
+	}))
+	defer server.Close()
+
+	redeemURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		codeVerifier string
+		expectedErr  bool
+	}{
+		{
+			name:         "OAuth2 flow without PKCE",
+			codeVerifier: "",
+			expectedErr:  false,
+		},
+		{
+			name:         "OAuth2 flow with PKCE",
+			codeVerifier: "test-code-verifier",
+			expectedErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &OpenShiftProvider{
+				ProviderData: &ProviderData{
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+					RedeemURL:    redeemURL,
+				},
+			}
+
+			session, err := provider.Redeem(context.Background(), "http://localhost/callback", "test-code", tt.codeVerifier)
+
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.Nil(t, session)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, session)
+				assert.Equal(t, "test-access-token", session.AccessToken)
+			}
+		})
+	}
+}
+
+func TestOpenShiftProviderRedeemMissingCode(t *testing.T) {
+	provider := &OpenShiftProvider{
+		ProviderData: &ProviderData{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+		},
+	}
+
+	session, err := provider.Redeem(context.Background(), "http://localhost/callback", "", "")
+	assert.Error(t, err)
+	assert.Nil(t, session)
+	assert.Contains(t, err.Error(), "missing code")
+}
+
+func TestOpenShiftProviderCacheKeyFormat(t *testing.T) {
+	tests := []struct {
+		name                string
+		useSystemTrustStore bool
+		caFiles             []string
+		expectedCacheKey    string
+	}{
+		{
+			name:                "System trust store enabled, single CA file",
+			useSystemTrustStore: true,
+			caFiles:             []string{"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+			expectedCacheKey:    "true:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+		},
+		{
+			name:                "System trust store disabled, single CA file",
+			useSystemTrustStore: false,
+			caFiles:             []string{"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+			expectedCacheKey:    "false:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+		},
+		{
+			name:                "System trust store enabled, multiple CA files",
+			useSystemTrustStore: true,
+			caFiles:             []string{"/custom/ca1.crt", "/custom/ca2.crt"},
+			expectedCacheKey:    "true:/custom/ca1.crt,/custom/ca2.crt",
+		},
+		{
+			name:                "System trust store disabled, multiple CA files",
+			useSystemTrustStore: false,
+			caFiles:             []string{"/custom/ca1.crt", "/custom/ca2.crt"},
+			expectedCacheKey:    "false:/custom/ca1.crt,/custom/ca2.crt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualKey := formatCacheKey(tt.useSystemTrustStore, tt.caFiles)
+			assert.Equal(t, tt.expectedCacheKey, actualKey)
+		})
+	}
+}
+
+func TestDiscoverValidateURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupEnv  func()
+		expectNil bool
+	}{
+		{
+			name: "Valid Kubernetes environment",
+			setupEnv: func() {
+				t.Setenv("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc")
+				t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+			},
+			expectNil: false,
+		},
+		{
+			name: "Default Kubernetes environment (uses hardcoded defaults)",
+			setupEnv: func() {
+				// Test with default environment (empty vars fall back to hardcoded defaults)
+			},
+			expectNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupEnv()
+
+			result, err := url.Parse(getKubeAPIURLWithPath(openShiftUserInfoPath))
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Contains(t, result.String(), "/apis/user.openshift.io/v1/users/~")
+				assert.Contains(t, result.String(), "https://")
+			}
+		})
+	}
+}
+
+// Helper function to test cache key formatting
+func formatCacheKey(useSystemTrustStore bool, capaths []string) string {
+	if useSystemTrustStore {
+		return "true:" + strings.Join(capaths, ",")
+	}
+	return "false:" + strings.Join(capaths, ",")
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -39,6 +39,8 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 	switch providerConfig.Type {
 	case options.OIDCProvider:
 		return NewOIDCProvider(providerData, providerConfig.OIDCConfig), nil
+	case options.OpenShiftProvider:
+		return NewOpenShiftProvider(providerData, providerConfig)
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", providerConfig.Type)
 	}
@@ -46,6 +48,7 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 
 func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, error) {
 	p := &ProviderData{
+		ProviderName:            providerConfig.Name,
 		Scope:                   providerConfig.Scope,
 		ClientID:                providerConfig.ClientID,
 		ClientSecret:            providerConfig.ClientSecret,
@@ -156,6 +159,8 @@ func providerRequiresOIDCProviderVerifier(providerType options.ProviderType) (bo
 	switch providerType {
 	case options.OIDCProvider:
 		return true, nil
+	case options.OpenShiftProvider:
+		return false, nil
 	default:
 		return false, fmt.Errorf("unknown provider type: %s", providerType)
 	}


### PR DESCRIPTION
### **Summary**

Adds OpenShift OAuth provider to enable authentication against OpenShift's built-in OAuth service, with full backward compatibility for existing `oauth-proxy` deployments.

### **Key Features**

- **OpenShift OAuth Provider**: Complete OAuth2 flow with service account auto-detection
- **oauth-proxy Compatibility**: `--openshift-service-account` and `--openshift-ca` flags for drop-in replacement
- **Auto-discovery**: Automatically finds OAuth endpoints and credentials in-cluster
- **Professional Documentation**: Usage examples and deployment guides

### **Usage**

```bash
# Service account auto-detection (recommended)
kube-auth-proxy \
  --provider=openshift \
  --openshift-service-account=my-sa \
  --upstream=http://my-app:8080

# Works with existing oauth-proxy configs (no changes needed)
kube-auth-proxy \
  --provider=openshift \
  --openshift-service-account=my-sa \
  --openshift-ca=/path/to/ca.crt \
  --upstream=http://my-app:8080
```







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added OpenShift provider with OAuth2 login, in-cluster endpoint discovery, and token validation.
  - Enabled service account auto-detection for client credentials; configurable custom CAs and system trust store.
  - Surfaced provider display name and merged CA settings from legacy options.
  - Forwarded access token, user, and email headers to upstreams.

- Documentation
  - Added OpenShift guides (manual and service account) with deployment examples and route integration.
  - Added OIDC example configs and deployment.
  - Documented new provider serviceAccount option.

- Tests
  - Added unit tests covering OpenShift flows, discovery, redemption, and legacy CA merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->