### PR TITLE
revamp the readme to reflect the new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once authenticated, the proxy forwards requests to upstream applications with ap
 
 #### Container Images
 
-Container images are currently under development (TBD). Once available, kube-auth-proxy will be distributed as container images built for multiple architectures:
+**⚠️ Container images are currently under development (TBD).** Once available, kube-auth-proxy will be distributed as container images built for multiple architectures:
 
 - **Standard Images**: Based on distroless for minimal attack surface
 - **FIPS Images**: FIPS-compliant builds for enterprise environments


### PR DESCRIPTION
Fixup the readme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded project to kube-auth-proxy with updated description, logos, and badges removed.
  * Added Key Features emphasizing OIDC, OpenShift OAuth, FIPS readiness, Envoy ext_authz support, and oauth-proxy compatibility.
  * Simplified architecture overview and clarified authn-only scope.
  * Reworked Installation with container images and binary releases; added Configuration section.
  * Provided OIDC and OpenShift usage examples.
  * Added Development and Testing guidance.
  * Included Security/Disclosure notes and Migration guide from oauth-proxy.
  * Updated Providers (OIDC, OpenShift), Repository History, License (MIT), and Acknowledgments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->