### PR TITLE
Add comprehensive OpenShift OAuth examples with scope validation

### DIFF
--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -59,3 +59,5 @@ curl -H "Authorization: Bearer $X_FORWARDED_ACCESS_TOKEN" \
 curl -H "Authorization: Bearer $X_FORWARDED_ACCESS_TOKEN" \
      https://api.cluster.example.com/apis/project.openshift.io/v1/projects
 ```
+
+> **Note**: Service account-based OAuth clients have limited scopes and can only access resources within their namespace or specific user information. Manual OAuth clients may have broader scope access depending on configuration.

--- a/examples/openshift/manual/config.yaml
+++ b/examples/openshift/manual/config.yaml
@@ -22,7 +22,7 @@ data:
   redirect-url: "https://your-app.apps.cluster.example.com/oauth2/callback"
   
   # OpenShift OAuth scope
-  scope: "user:info"
+  scope: "user:full"
   
   # Header forwarding
   pass-basic-auth: "false"

--- a/examples/openshift/service-account/config.yaml
+++ b/examples/openshift/service-account/config.yaml
@@ -29,6 +29,7 @@ data:
   redirect-url: "https://your-app.apps.cluster.example.com/oauth2/callback"
   
   # OpenShift OAuth scope
+  # For more: https://docs.redhat.com/en/documentation/openshift_container_platform/4.9/html/authentication_and_authorization/using-service-accounts-as-oauth-client#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client
   scope: "user:info"
   
   # Header forwarding

--- a/providers/openshift.go
+++ b/providers/openshift.go
@@ -17,9 +17,9 @@ import (
 	"time"
 
 	"github.com/bitly/go-simplejson"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/apis/options"
+	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/apis/sessions"
+	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/logger"
 )
 
 const (
@@ -73,10 +73,15 @@ func NewOpenShiftProvider(p *ProviderData, cfg options.Provider) (*OpenShiftProv
 		name = p.ProviderName
 	}
 
+	scope := openShiftDefaultScope
+	if p.Scope != "" {
+		scope = p.Scope
+	}
+
 	// Set provider defaults
 	defaults := providerDefaults{
 		name:        name,
-		scope:       openShiftDefaultScope,
+		scope:       scope,
 		loginURL:    nil,
 		redeemURL:   nil,
 		validateURL: nil,

--- a/providers/openshift_test.go
+++ b/providers/openshift_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/apis/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Summary
Fixes OpenShift provider to respect configured scope and adds comprehensive examples documenting OAuth scope limitations.

## Bug Fix
- **Fixed scope override bug** in `providers/openshift.go` - provider now respects user-configured scope instead of hardcoding `user:info`

## Examples Added
- **Service Account OAuth**: Simple auto-detection approach with scope limitations
- **Manual OAuth Client**: Traditional setup supporting broader scopes
- Complete deployment examples for both approaches

## Key Documentation
- **Service account OAuth scope limitations**: Constrained to `user:info`, `user:check-access`, and namespace-specific roles only
- **Manual OAuth clients**: Support broader scopes like `user:full` for wider API access

## Validation
- ✅ Scope override fix tested with `user:full` scope
- ✅ Service account approach limitations confirmed (groups API blocked by scope)
- ✅ Manual OAuth client broader access verified
- ✅ Both approaches work independently on live ROSA cluster



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - OpenShift provider now supports a configurable default OAuth scope.
- Documentation
  - Clarified OAuth scope differences between service account and manual clients in the OpenShift guide, with added reference link.
- Examples
  - Updated OpenShift manual configuration to use a broader OAuth scope.
  - Added explanatory comment to the service account example about OAuth scopes.
- Refactor
  - Updated internal dependencies to new module paths.
- Tests
  - Adjusted tests to align with updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->