### PR TITLE
new dockerfile.redhat and modified makefile for fips compliance

### DIFF
--- a/.github/workflows/fips-compliance.yml
+++ b/.github/workflows/fips-compliance.yml
@@ -1,0 +1,55 @@
+name: FIPS Compliance Check
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  fips-compliance:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
+    - name: Build FIPS-compliant image
+      run: |
+        docker build -f Dockerfile.redhat \
+          -t kube-auth-proxy:fips-test \
+          --build-arg VERSION=test \
+          --build-arg BUILDPLATFORM=linux/amd64 \
+          .
+    
+    - name: Setup Go for check-payload
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+    
+    - name: Clone and build check-payload tool
+      run: |
+        git clone https://github.com/openshift/check-payload.git /tmp/check-payload
+        cd /tmp/check-payload
+        make
+    
+    - name: Extract container filesystem for scanning
+      run: |
+        mkdir -p /tmp/container-fs
+        docker create --name temp-fips-container kube-auth-proxy:fips-test
+        docker export temp-fips-container | tar -x -C /tmp/container-fs
+        docker rm temp-fips-container
+    
+    - name: Run FIPS compliance check
+      run: |
+        /tmp/check-payload/check-payload scan local --path /tmp/container-fs
+    
+    - name: Upload build artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: fips-compliance-logs
+        path: |
+          kube-auth-proxy-fips.tar
+        retention-days: 7

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -1,0 +1,80 @@
+# Dockerfile.redhat - FIPS-compliant build for Red Hat environments
+# Argument for setting the oauth2-proxy build version
+ARG VERSION
+
+# All builds should be done using the platform native to the build node to allow
+#  cache sharing of the go mod download step.
+# Go cross compilation is also faster than emulation the go compilation across
+#  multiple platforms.
+FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+
+# Switch to root for build permissions
+USER root
+
+# Copy sources
+WORKDIR $GOPATH/src/github.com/opendatahub-io/kube-auth-proxy
+
+# Fetch dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Now pull in our code
+COPY . .
+
+# Arguments go here so that the previous steps can be cached if no external sources
+# have changed. These arguments are automatically set by the docker engine.
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+# Reload version argument
+ARG VERSION
+
+# Build FIPS-compliant binary and make sure there is at least an empty key file.
+#  This is useful for GCP App Engine custom runtime builds, because
+#  you cannot use multiline variables in their app.yaml, so you have to
+#  build the key into the container and then tell it where it is
+#  by setting OAUTH2_PROXY_JWT_KEY_FILE=/etc/ssl/private/jwt_signing_key.pem
+#  in app.yaml instead.
+# Set the cross compilation arguments based on the TARGETPLATFORM which is
+#  automatically set by the docker engine.
+RUN case ${TARGETPLATFORM} in \
+         "linux/amd64")  GOARCH=amd64  ;; \
+         # arm64 and arm64v8 are equivalent in go and do not require a goarm
+         # https://github.com/golang/go/wiki/GoArm
+         "linux/arm64" | "linux/arm/v8")  GOARCH=arm64  ;; \
+         "linux/ppc64le")  GOARCH=ppc64le  ;; \
+         "linux/s390x")  GOARCH=s390x  ;; \
+         "linux/arm/v6") GOARCH=arm GOARM=6  ;; \
+         "linux/arm/v7") GOARCH=arm GOARM=7 ;; \
+    esac && \
+    printf "Building FIPS-compliant OAuth2 Proxy for arch ${GOARCH}\n" && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GOEXPERIMENT=strictfipsruntime \
+    go build -a -tags strictfipsruntime \
+    -ldflags="-X github.com/opendatahub-io/kube-auth-proxy/v1/pkg/version.VERSION=${VERSION}" \
+    -o kube-auth-proxy github.com/opendatahub-io/kube-auth-proxy/v1 && \
+    touch jwt_signing_key.pem
+
+# Copy binary to FIPS-compliant runtime image
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+# Reload version
+ARG VERSION
+
+WORKDIR /
+COPY --from=builder $GOPATH/src/github.com/opendatahub-io/kube-auth-proxy/kube-auth-proxy /bin/kube-auth-proxy
+COPY --chown=1001:0 --from=builder $GOPATH/src/github.com/opendatahub-io/kube-auth-proxy/jwt_signing_key.pem /etc/ssl/private/jwt_signing_key.pem
+
+# Set proper permissions for non-root execution
+RUN chown -R 1001:0 /etc/ssl/private && \
+    chmod -R g=u /etc/ssl/private
+
+USER 1001
+
+LABEL org.opencontainers.image.licenses=MIT \
+      org.opencontainers.image.description="A reverse proxy that provides authentication with Google, Azure, OpenID Connect and many more identity providers. (FIPS-compliant)" \
+      org.opencontainers.image.documentation=https://github.com/opendatahub-io/kube-auth-proxy \
+      org.opencontainers.image.source=https://github.com/opendatahub-io/kube-auth-proxy \
+      org.opencontainers.image.url=https://quay.io/opendatahub/kube-auth-proxy \
+      org.opencontainers.image.title=kube-auth-proxy \
+      org.opencontainers.image.version=${VERSION}
+
+ENTRYPOINT ["/bin/kube-auth-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ build: validate-go-version clean $(BINARY) ## Build and create kube-auth-proxy b
 $(BINARY):
 	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/opendatahub-io/kube-auth-proxy/v1/pkg/version.VERSION=${VERSION}" -o $@ github.com/opendatahub-io/kube-auth-proxy/v1
 
+.PHONY: build-fips
+build-fips: validate-go-version clean ## Build FIPS-compliant kube-auth-proxy binary
+	CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime $(GO) build -a -tags strictfipsruntime -ldflags="-X github.com/opendatahub-io/kube-auth-proxy/v1/pkg/version.VERSION=${VERSION}" -o $(BINARY) github.com/opendatahub-io/kube-auth-proxy/v1
+
 DOCKER_BUILDX_COMMON_ARGS     ?= --build-arg BUILD_IMAGE=docker.io/library/golang:${GO_MOD_VERSION}-bookworm --build-arg VERSION=${VERSION}
 
 DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7,linux/s390x
@@ -82,6 +86,10 @@ build-distroless: ## Build multi architecture distroless based docker image
 .PHONY: build-alpine
 build-alpine: ## Build multi architecture alpine based docker image
 	$(DOCKER_BUILDX_X_PLATFORM_ALPINE) -t $(REGISTRY)/$(REPOSITORY):latest-alpine -t $(REGISTRY)/$(REPOSITORY):${VERSION}-alpine .
+
+.PHONY: build-docker-fips
+build-docker-fips: ## Build FIPS-compliant docker image using Dockerfile.redhat
+	$(DOCKER_BUILDX_X_PLATFORM) -f Dockerfile.redhat -t $(REGISTRY)/$(REPOSITORY):fips -t $(REGISTRY)/$(REPOSITORY):${VERSION}-fips .
 
 .PHONY: build-docker-all
 build-docker-all: build-docker ## Build docker images for all supported architectures in both flavours (distroless / alpine)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Jira: [RHOAIENG-32505](https://issues.redhat.com/browse/RHOAIENG-32505)

## How Has This Been Tested?
Created two images one with latest and latest-fips, verified with `https://github.com/openshift/check-payload`

`podman pull quay.io/csantiago/kube-auth-proxy:latest-fips`
```bash
podman unshare ./check-payload scan image --spec=quay.io/csantiago/kube-auth-proxy:fips-latest
I0825 17:17:58.021790  355872 main.go:306] using config file: config.toml
I0825 17:17:58.021820  355872 main.go:102] "scan" version="0.3.10-0-g1c354196"
---- Successful run
```

`podman pull quay.io/csantiago/kube-auth-proxy:latest`
```bash
podman unshare ./check-payload scan image --spec=quay.io/csantiago/kube-auth-proxy:latest                          
I0825 17:17:50.474213  355772 main.go:306] using config file: config.toml              
I0825 17:17:50.474257  355772 main.go:102] "scan" version="0.3.10-0-g1c354196"
I0825 17:17:52.760431  355772 validations.go:421] rpm -qf error: exit status 1 (stderr=)
I0825 17:17:52.760461  355772 scan.go:460] "scanning failed" image="quay.io/csantiago/kube-auth-proxy:latest" path="/usr/bin/kube-auth-proxy" error="go binary is not CGO_ENABLED" component="ubi9-minimal-container" tag="" rpm="" status="failed"
---- Failure Report
+------------------------+--------------------------+------------------------------+------------------------------------------+
| OPERATOR NAME          | EXECUTABLE NAME          | STATUS                       | IMAGE                                    |
+------------------------+--------------------------+------------------------------+------------------------------------------+
| ubi9-minimal-container | /usr/bin/kube-auth-proxy | go binary is not CGO_ENABLED | quay.io/csantiago/kube-auth-proxy:latest |
+------------------------+--------------------------+------------------------------+------------------------------------------+
F0825 17:17:52.808106  355772 main.go:294] Error: run failed
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added FIPS-compliant build target to produce FIPS-enabled binaries.
  - Introduced a Red Hat–based multi-arch container build that produces FIPS-compliant images.
  - Container runs as non-root, enforces a fixed JWT key path, and includes standard image metadata labels.

- **Chores**
  - Added Makefile targets and .PHONY entries for FIPS builds.
  - Added Dockerfile.redhat to support FIPS image creation.
  - Added a GitHub Actions FIPS compliance check workflow for PR validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->