### PR TITLE
chore: Update quay tag for ODH v3.4.0-ea.2 release

### DIFF
--- a/.tekton/kube-auth-proxy-push.yaml
+++ b/.tekton/kube-auth-proxy-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-kube-auth-proxy:v3.4-ea.1
+    value: quay.io/opendatahub/odh-kube-auth-proxy:v3.4-ea.2
   - name: dockerfile
     value: Dockerfile.redhat
   - name: path-context


### PR DESCRIPTION
Updates the output-image tag in the Tekton push pipeline from `v3.4-ea.1` to `v3.4.0-ea.2` to match the [v3.4.0-ea.2 release](https://github.com/opendatahub-io/kube-auth-proxy/releases/tag/v3.4.0-ea.2).