### PR TITLE
Use id_token instead of access_token for pass-access-token and x-auth-request headers

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -333,7 +333,7 @@ func NewPassAccessTokenTest(opts PassAccessTokenTestOptions) (*PassAccessTokenTe
 			var payload string
 			switch r.URL.Path {
 			case "/oauth/token":
-				payload = `{"access_token": "my_auth_token"}`
+				payload = `{"access_token": "my_auth_token", "id_token": "my_auth_token"}`
 			default:
 				payload = r.Header.Get("X-Forwarded-Access-Token")
 				if payload == "" {
@@ -369,7 +369,7 @@ func NewPassAccessTokenTest(opts PassAccessTokenTestOptions) (*PassAccessTokenTe
 				Values: []options.HeaderValue{
 					{
 						ClaimSource: &options.ClaimSource{
-							Claim: "access_token",
+							Claim: "id_token",
 						},
 					},
 				},

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -354,7 +354,7 @@ func getPassAccessTokenHeader() Header {
 		Values: []HeaderValue{
 			{
 				ClaimSource: &ClaimSource{
-					Claim: "access_token",
+					Claim: "id_token",
 				},
 			},
 		},
@@ -441,7 +441,7 @@ func getXAuthRequestAccessTokenHeader() Header {
 		Values: []HeaderValue{
 			{
 				ClaimSource: &ClaimSource{
-					Claim: "access_token",
+					Claim: "id_token",
 				},
 			},
 		},

--- a/pkg/apis/options/legacy_options_test.go
+++ b/pkg/apis/options/legacy_options_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Legacy Options", func() {
 			Values: []HeaderValue{
 				{
 					ClaimSource: &ClaimSource{
-						Claim: "access_token",
+						Claim: "id_token",
 					},
 				},
 			},
@@ -459,7 +459,7 @@ var _ = Describe("Legacy Options", func() {
 			Values: []HeaderValue{
 				{
 					ClaimSource: &ClaimSource{
-						Claim: "access_token",
+						Claim: "id_token",
 					},
 				},
 			},

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -82,11 +82,13 @@ func (p *ProviderData) Redeem(ctx context.Context, redirectURL, code, codeVerifi
 	// blindly try json and x-www-form-urlencoded
 	var jsonResponse struct {
 		AccessToken string `json:"access_token"`
+		IDToken     string `json:"id_token"`
 	}
 	err = result.UnmarshalInto(&jsonResponse)
 	if err == nil {
 		return &sessions.SessionState{
 			AccessToken: jsonResponse.AccessToken,
+			IDToken:     jsonResponse.IDToken,
 		}, nil
 	}
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The --pass-access-token and --set-xauthrequest flags now forward the id_token claim instead of access_token, so that the downstream kube-rbac-proxy receives the OIDC id_token for authentication.

Also updates ProviderData.Redeem to capture id_token from the token response JSON when present.

## How Has This Been Tested?

1. Setup cluster for BYOIDC with EntraID
2. Installed a nightly build of 3.4.ea1 
3. Tried accessing the dashboard


## Checklist:


- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ID token handling in OAuth2 token responses.

* **Bug Fixes**
  * Updated token forwarding headers to use ID tokens instead of access tokens for improved OAuth2 standard compliance.

* **Tests**
  * Updated test expectations to reflect ID token usage in token forwarding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->