### PR TITLE
feat: improve AI bug automation readiness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,34 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: [--allow-multiple-documents]
       - id: check-added-large-files
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.0
+      - id: check-merge-conflict
+
+  - repo: local
     hooks:
-    - id: golangci-lint
-    - id: go-build
+      - id: go-fmt
+        name: go fmt
+        entry: gofmt -w
+        language: system
+        types: [go]
+      - id: go-vet
+        name: go vet
+        entry: go vet ./...
+        language: system
+        pass_filenames: false
+      - id: golangci-lint
+        name: golangci-lint
+        entry: make lint
+        language: system
+        pass_filenames: false
+      - id: go-unit-tests
+        name: go test
+        entry: make test
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# kube-auth-proxy Agent Guidelines
+
+## Project Overview
+
+Authentication proxy for OpenShift AI (RHOAI) that handles both external OIDC providers and OpenShift's internal OAuth service. FIPS-compliant. Includes `kube-rbac-proxy` as a subproject under `kube-rbac-proxy/`.
+
+## Architecture
+
+```text
+cmd/                - CLI entry point (not used directly, main.go is root-level)
+pkg/                - Core packages (apis, encryption, options, version)
+providers/          - Authentication provider implementations (OIDC, OpenShift OAuth)
+kube-rbac-proxy/    - Embedded kube-rbac-proxy subproject (separate go.mod)
+contrib/            - Deployment manifests
+examples/           - Example configurations
+docs/               - Docusaurus documentation site
+```
+
+Main entry point is `main.go` at repo root. OAuth proxy logic is in `oauthproxy.go`.
+
+## Build and Run
+
+```bash
+make build              # Build kube-auth-proxy binary
+make build-fips         # Build FIPS-compliant binary
+make build-docker       # Build multi-arch docker image
+make test               # Run lint + all tests
+make test-integration   # Run integration tests only
+make lint               # Run golangci-lint
+make lint-fix           # Auto-fix lint issues
+make clean              # Remove built binary
+make verify-generate    # Verify code generation is up to date
+```
+
+## Test Guidelines
+
+- Tests use standard Go testing (`go test`)
+- Integration tests use build tag `integration`
+- Test files: `*_test.go` at repo root and in packages
+- Coverage enabled via `COVER=true` environment variable
+- CI uses Code Climate for coverage reporting
+
+## Debug and Troubleshooting
+
+- Run `make lint` first for any code issues
+- For test failures: `go test -v -race ./...`
+- For integration tests: `go test -tags integration -v -race .`
+- Check `.golangci.yml` for linter configuration
+- DESIGN.md contains full architecture and requirements documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,42 @@
 # Contributing
 
-To develop on this project, please fork the repo and clone into your `$GOPATH`.
+To develop on this project, please fork the repo and clone it locally.
 
-Dependencies are **not** checked in so please download those separately.
-Download the dependencies using `go mod download`.
+## Development Setup
+
+### Prerequisites
+
+- Go (version specified in `go.mod`)
+- golangci-lint
+- Docker with buildx (for container builds)
+- pre-commit (`pipx install pre-commit && pre-commit install`)
+
+### Build
 
 ```bash
-cd $GOPATH/src/github.com # Create this directory if it doesn't exist
-git clone git@github.com:<YOUR_FORK>/oauth2-proxy oauth2-proxy/oauth2-proxy
-cd oauth2-proxy/oauth2-proxy
-go mod download
+make build          # Build the kube-auth-proxy binary
+make build-fips     # Build FIPS-compliant binary
+```
+
+### Test
+
+```bash
+make test               # Run lint + all tests with race detection
+make test-integration   # Run integration tests only
+COVER=true make test    # Run tests with coverage
+```
+
+### Lint
+
+```bash
+make lint       # Run golangci-lint
+make lint-fix   # Auto-fix lint issues
+```
+
+### Code Generation
+
+```bash
+make verify-generate    # Verify generated code is up to date
 ```
 
 ## Pull Requests and Issues

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+This project's ADRs are maintained in the organization-level repository:
+
+https://github.com/opendatahub-io/architecture-decision-records


### PR DESCRIPTION
## Summary

Improves AI bug automation readiness score from 73 to 85/100 ("Ready" tier).

Changes:
- **AGENTS.md**: Add tool-agnostic agent guidelines with project overview, architecture, build/test/debug commands
- **.pre-commit-config.yaml**: Replace archived `dnephin/pre-commit-golang` with local hooks (go-fmt, go-vet, golangci-lint, tests), update pre-commit-hooks to v5.0.0
- **CONTRIBUTING.md**: Expand with prerequisites, build, test, lint, and code generation sections
- **docs/adr/README.md**: Add pointer to organization-level ADR repository

## Score Breakdown

| Check | Before | After | Delta |
|-------|--------|-------|-------|
| Agent Context (AGENTS.md) | 0 | 8 | +8 |
| Pre-commit Hooks | 1.5 | 1.5 | 0 |
| ADR Directory | 0 | 3 | +3 |
| Contributing Guide | 2 | 3 | +1 |
| **Total** | **73** | **85** | **+12** |

## Test plan
- [ ] Verify pre-commit hooks run correctly: `pre-commit run --all-files`
- [ ] Verify `make build`, `make test`, `make lint` still work
- [ ] Review AGENTS.md content for accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added agent guidelines covering project overview, architecture, entry points, build/run/verification workflows, testing conventions, and debugging steps
  * Added an Architecture Decision Records index
  * Updated the contribution guide with local development setup, standardized make targets for build/test/lint, and generation verification

* **Chores**
  * Updated pre-commit configuration: bumped hook versions, adjusted YAML checking and merge-conflict checks, and replaced external Go hooks with local Go checks (format, vet, lint, and unit-test steps, including pre-push test enforcement)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->