### PR TITLE
fix: generalize OIDC logout to work with any provider, not just Keycloak

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"embed"
 	"encoding/base64"
 	"encoding/json"
@@ -55,6 +56,11 @@ const (
 	authOnlyPath      = "/auth"
 	userInfoPath      = "/userinfo"
 	staticPathPrefix  = "/static/"
+
+	// OpenShift OAuthAccessToken API
+	oauthAccessTokenAPIPath = "/apis/oauth.openshift.io/v1/oauthaccesstokens" // #nosec G101
+	kubeServiceHost         = "kubernetes.default.svc"
+	sha256Prefix            = "sha256~"
 )
 
 var (
@@ -793,6 +799,15 @@ func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Delete OAuthAccessToken in the background (OpenShift provider only).
+	// This is best-effort and must not block the logout response.
+	if session != nil {
+		accessToken := session.AccessToken
+		go func() {
+			p.deleteOAuthAccessToken(&sessionsapi.SessionState{AccessToken: accessToken})
+		}()
+	}
+
 	if err := p.ClearSessionCookie(rw, req); err != nil {
 		logger.Errorf("Error clearing session cookie: %v", err)
 		p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
@@ -815,6 +830,65 @@ func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	http.Redirect(rw, req, redirect, http.StatusFound)
+}
+
+// deleteOAuthAccessToken deletes the OAuthAccessToken resource from the cluster
+// when using the OpenShift provider. This matches what the OCP console does on logout.
+// Reference: https://github.com/openshift/console/pull/6445
+// For sha256~ prefixed tokens, the resource name is the sha256 hash of the raw
+// token part, not the bearer token itself.
+func (p *OAuthProxy) deleteOAuthAccessToken(session *sessionsapi.SessionState) {
+	if session.AccessToken == "" {
+		return
+	}
+
+	openshiftProvider, ok := p.provider.(*providers.OpenShiftProvider)
+	if !ok {
+		return
+	}
+
+	tokenName := session.AccessToken
+	if strings.HasPrefix(tokenName, sha256Prefix) {
+		tokenName = tokenToObjectName(tokenName)
+	}
+
+	deleteURL := fmt.Sprintf("%s://%s%s/%s", schemeHTTPS, kubeServiceHost, oauthAccessTokenAPIPath, tokenName)
+
+	req, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+	if err != nil {
+		logger.Errorf("SignOut: failed to create OAuthAccessToken delete request: %v", err)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+session.AccessToken)
+
+	client, err := openshiftProvider.NewHTTPClient()
+	if err != nil {
+		logger.Errorf("SignOut: failed to create HTTP client for OAuthAccessToken deletion: %v", err)
+		return
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Errorf("SignOut: failed to delete OAuthAccessToken: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
+		logger.Printf("SignOut: deleted OAuthAccessToken (status %d)", resp.StatusCode)
+	} else {
+		logger.Errorf("SignOut: failed to delete OAuthAccessToken: status %d", resp.StatusCode)
+	}
+}
+
+// tokenToObjectName converts a sha256~ prefixed bearer token to its
+// OAuthAccessToken resource name. The resource name is sha256~<base64url(sha256(raw))>
+// where raw is the token with the sha256~ prefix stripped.
+// Reference: https://github.com/openshift/console/pull/6431
+func tokenToObjectName(token string) string {
+	raw := strings.TrimPrefix(token, sha256Prefix)
+	h := sha256.Sum256([]byte(raw))
+	return sha256Prefix + base64.RawURLEncoding.EncodeToString(h[:])
 }
 
 func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request) {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -105,7 +105,6 @@ type OAuthProxy struct {
 	allowQuerySemicolons bool
 	realClientIPParser   ipapi.RealClientIPParser
 	trustedIPs           *ip.NetSet
-	cachedLogoutURL      string
 
 	sessionChain      alice.Chain
 	headersChain      alice.Chain
@@ -785,40 +784,37 @@ func (p *OAuthProxy) UserInfo(rw http.ResponseWriter, req *http.Request) {
 
 // SignOut sends a response to clear the authentication cookie
 func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
-	// Get redirect URL and session in parallel
 	redirect, redirectErr := p.appDirector.GetRedirect(req)
 	session, _ := p.getAuthenticatedSession(rw, req)
 
-	// Handle redirect error
 	if redirectErr != nil {
 		logger.Errorf("Error obtaining redirect: %v", redirectErr)
 		p.ErrorPage(rw, req, http.StatusInternalServerError, redirectErr.Error())
 		return
 	}
 
-	// Clear session cookie
 	if err := p.ClearSessionCookie(rw, req); err != nil {
 		logger.Errorf("Error clearing session cookie: %v", err)
 		p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	// Choose logout strategy based on configuration
+	// Backend logout: server-side call to IdP, then redirect
 	providerData := p.provider.Data()
 	if providerData.BackendLogoutURL != "" {
-		// Backend logout: server-side call to IdP
 		p.backendLogout(rw, req)
 		http.Redirect(rw, req, redirect, http.StatusFound)
 		return
 	}
 
-	// Frontend logout: redirect browser to IdP logout endpoint (OIDC only)
+	// OIDC frontend logout: redirect browser to IdP's end_session_endpoint
+	// so the IdP can clear its SSO session. Same approach as OCP console.
 	if p.isOIDCProvider() {
-		p.frontendLogout(rw, req, session, redirect)
-	} else {
-		// For non-OIDC providers, use simple redirect
-		http.Redirect(rw, req, redirect, http.StatusFound)
+		p.frontendLogout(rw, req, session)
+		return
 	}
+
+	http.Redirect(rw, req, redirect, http.StatusFound)
 }
 
 func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request) {
@@ -872,150 +868,41 @@ func redactSensitiveQueryParams(rawURL string) string {
 	return parsedURL.String()
 }
 
-// frontendLogout handles browser-based logout by redirecting to the IdP logout endpoint
-func (p *OAuthProxy) frontendLogout(rw http.ResponseWriter, req *http.Request, session *sessionsapi.SessionState, fallbackRedirect string) {
-	// Try to get the logout URL (cached or discovered)
+// frontendLogout redirects the browser to the IdP's end_session_endpoint
+// so the IdP can clear its SSO session. The local session cookie is already
+// cleared by the caller. This matches the OCP console logout approach.
+func (p *OAuthProxy) frontendLogout(rw http.ResponseWriter, req *http.Request, session *sessionsapi.SessionState) {
 	logoutURL := p.getLogoutURL()
 	if logoutURL == "" {
-		// Fallback: simple redirect if no logout URL available
-		logger.Printf("SignOut: No logout URL available, using fallback redirect")
-		http.Redirect(rw, req, fallbackRedirect, http.StatusFound)
+		logger.Printf("SignOut: No logout URL available, redirecting to /")
+		http.Redirect(rw, req, "/", http.StatusFound)
 		return
 	}
 
-	// Add id_token_hint if session and token are available
 	if session != nil && session.IDToken != "" {
 		separator := "?"
 		if strings.Contains(logoutURL, "?") {
 			separator = "&"
 		}
 		logoutURL += separator + "id_token_hint=" + url.QueryEscape(session.IDToken)
-		logger.Printf("SignOut: Redirecting to OIDC logout with id_token_hint")
-	} else {
-		logger.Printf("SignOut: Redirecting to OIDC logout without id_token_hint")
 	}
 
-	logger.Printf("SignOut: Using logout URL: %s", redactSensitiveQueryParams(logoutURL))
+	logger.Printf("SignOut: Redirecting to IdP logout: %s", redactSensitiveQueryParams(logoutURL))
 	http.Redirect(rw, req, logoutURL, http.StatusFound)
 }
 
-// discoverLogoutURL fetches the logout URL from OIDC .well-known endpoint
-func (p *OAuthProxy) discoverLogoutURL() (string, error) {
-	providerData := p.provider.Data()
-
-	// Validate that LoginURL is available and properly formatted
-	if providerData.LoginURL == nil {
-		return "", fmt.Errorf("could not determine issuer URL for OIDC discovery")
-	}
-
-	loginURL := providerData.LoginURL
-
-	// Ensure LoginURL has HTTPS scheme and a host for security
-	if loginURL.Scheme != "https" {
-		return "", fmt.Errorf("could not determine issuer URL for OIDC discovery")
-	}
-	if loginURL.Host == "" {
-		return "", fmt.Errorf("could not determine issuer URL for OIDC discovery")
-	}
-
-	// Derive issuer URL by parsing and manipulating the login URL
-	// For Keycloak OIDC: https://host/realms/realm/protocol/openid-connect/auth -> https://host/realms/realm
-	issuerURL := &url.URL{
-		Scheme: loginURL.Scheme,
-		Host:   loginURL.Host,
-	}
-
-	// Trim known OIDC path segments to get the issuer
-	loginPath := loginURL.Path
-	if strings.HasSuffix(loginPath, "/protocol/openid-connect/auth") {
-		issuerURL.Path = strings.TrimSuffix(loginPath, "/protocol/openid-connect/auth")
-	} else {
-		return "", fmt.Errorf("could not determine issuer URL for OIDC discovery")
-	}
-
-	// Construct .well-known URL using proper URL methods
-	wellKnownPath := strings.TrimSuffix(issuerURL.Path, "/") + "/.well-known/openid-configuration"
-	wellKnownURL := &url.URL{
-		Scheme: issuerURL.Scheme,
-		Host:   issuerURL.Host,
-		Path:   wellKnownPath,
-	}
-
-	// Verify well-known URL host matches login URL host to prevent SSRF
-	if wellKnownURL.Host != loginURL.Host {
-		return "", fmt.Errorf("could not determine issuer URL for OIDC discovery")
-	}
-
-	// Create HTTP client with timeout to prevent hanging requests
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	// Create request with context and timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	wellKnownURLStr := wellKnownURL.String()
-	req, err := http.NewRequestWithContext(ctx, "GET", wellKnownURLStr, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch OIDC discovery document: %v", err)
-	}
-
-	// #nosec G107 -- wellKnownURL host validated to match provider LoginURL host and using timeout
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch OIDC discovery document: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("OIDC discovery document returned status %d", resp.StatusCode)
-	}
-
-	// Parse the JSON response
-	var discovery struct {
-		EndSessionEndpoint string `json:"end_session_endpoint"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
-		return "", fmt.Errorf("failed to parse OIDC discovery document: %v", err)
-	}
-
-	if discovery.EndSessionEndpoint == "" {
-		return "", fmt.Errorf("end_session_endpoint not found in OIDC discovery document")
-	}
-
-	logger.Printf("Discovered OIDC logout URL: %s", discovery.EndSessionEndpoint)
-	return discovery.EndSessionEndpoint, nil
-}
-
-// getLogoutURL returns the cached logout URL or discovers it if not cached
+// getLogoutURL returns the end_session_endpoint discovered at startup.
 func (p *OAuthProxy) getLogoutURL() string {
-	// Check if we have a cached logout URL
-	if p.cachedLogoutURL != "" {
-		return p.cachedLogoutURL
+	if esURL := p.provider.Data().EndSessionURL; esURL != nil {
+		return esURL.String()
 	}
-
-	// Discover and cache the logout URL
-	if logoutURL, err := p.discoverLogoutURL(); err == nil && logoutURL != "" {
-		p.cachedLogoutURL = logoutURL
-		return logoutURL
-	}
-
-	// Return empty string if discovery fails
 	return ""
 }
 
-// isOIDCProvider checks if the current provider is OIDC-based
+// isOIDCProvider checks if the current provider supports RP-initiated logout
+// by verifying that end_session_endpoint was discovered during startup.
 func (p *OAuthProxy) isOIDCProvider() bool {
-	providerData := p.provider.Data()
-	// Check if this is an OIDC provider by looking for OIDC-specific URLs
-	// OIDC providers typically have login URLs ending with /protocol/openid-connect/auth
-	if providerData.LoginURL != nil {
-		loginURL := providerData.LoginURL.String()
-		return strings.Contains(loginURL, "/protocol/openid-connect/auth")
-	}
-	return false
+	return p.provider.Data().EndSessionURL != nil
 }
 
 // OAuthStart starts the OAuth2 authentication flow

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -3581,3 +3581,93 @@ func TestOAuthCallbackMissingCSRFReturns403WhenRedirectDisabled(t *testing.T) {
 	assert.Contains(t, body, "403", "body should be error page")
 	assert.Contains(t, body, "CSRF", "body should mention CSRF")
 }
+
+func TestIsOIDCProviderWithEndSessionURL(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	endSessionURL, _ := url.Parse("https://login.microsoftonline.com/tenant/oauth2/v2.0/logout")
+	proxy.provider.Data().EndSessionURL = endSessionURL
+
+	assert.True(t, proxy.isOIDCProvider(), "should return true when EndSessionURL is set")
+}
+
+func TestIsOIDCProviderWithoutEndSessionURL(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	proxy.provider.Data().EndSessionURL = nil
+
+	assert.False(t, proxy.isOIDCProvider(), "should return false when EndSessionURL is nil")
+}
+
+func TestGetLogoutURLReturnsEndSessionURL(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	expected := "https://login.microsoftonline.com/tenant/oauth2/v2.0/logout"
+	endSessionURL, _ := url.Parse(expected)
+	proxy.provider.Data().EndSessionURL = endSessionURL
+
+	assert.Equal(t, expected, proxy.getLogoutURL())
+}
+
+func TestGetLogoutURLReturnsEmptyWhenNil(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	proxy.provider.Data().EndSessionURL = nil
+
+	assert.Empty(t, proxy.getLogoutURL())
+}
+
+func TestSignOutOIDCClearsCookieAndRedirectsToIdP(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	endSessionURL, _ := url.Parse("https://login.microsoftonline.com/tenant/oauth2/v2.0/logout")
+	proxy.provider.Data().EndSessionURL = endSessionURL
+
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/oauth2/sign_out", nil)
+	proxy.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusFound, rw.Code)
+
+	location := rw.Header().Get("Location")
+	assert.Contains(t, location, "https://login.microsoftonline.com/tenant/oauth2/v2.0/logout")
+	assert.NotContains(t, location, "post_logout_redirect_uri")
+	assert.NotContains(t, location, "state=logout")
+}
+
+func TestSignOutNonOIDCClearsCookieDirectly(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	proxy.provider.Data().EndSessionURL = nil
+
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/oauth2/sign_out", nil)
+	proxy.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusFound, rw.Code)
+	assert.NotContains(t, rw.Header().Get("Location"), "login.microsoftonline.com")
+}

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -3671,3 +3671,28 @@ func TestSignOutNonOIDCClearsCookieDirectly(t *testing.T) {
 	assert.Equal(t, http.StatusFound, rw.Code)
 	assert.NotContains(t, rw.Header().Get("Location"), "login.microsoftonline.com")
 }
+
+func TestDeleteOAuthAccessTokenSkipsForNonOpenShiftProvider(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	// Default test provider is not OpenShift, so this should be a no-op
+	proxy.deleteOAuthAccessToken(&sessions.SessionState{
+		AccessToken: "sha256~test-token",
+	})
+}
+
+func TestDeleteOAuthAccessTokenSkipsWhenAccessTokenEmpty(t *testing.T) {
+	opts := baseTestOptions()
+	require.NoError(t, validation.Validate(opts))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	require.NoError(t, err)
+
+	proxy.deleteOAuthAccessToken(&sessions.SessionState{
+		AccessToken: "",
+	})
+}

--- a/pkg/providers/oidc/provider.go
+++ b/pkg/providers/oidc/provider.go
@@ -16,6 +16,7 @@ type providerJSON struct {
 	TokenURL             string   `json:"token_endpoint"`
 	JWKsURL              string   `json:"jwks_uri"`
 	UserInfoURL          string   `json:"userinfo_endpoint"`
+	EndSessionURL        string   `json:"end_session_endpoint"`
 	CodeChallengeAlgs    []string `json:"code_challenge_methods_supported"`
 	SupportedSigningAlgs []string `json:"id_token_signing_alg_values_supported"`
 }
@@ -41,6 +42,7 @@ type DiscoveryProvider interface {
 	Endpoints() Endpoints
 	PKCE() PKCE
 	SupportedSigningAlgs() []string
+	EndSessionURL() string
 }
 
 // NewProvider allows a user to perform an OIDC discovery and returns the DiscoveryProvider.
@@ -69,6 +71,7 @@ func NewProvider(ctx context.Context, issuerURL string, skipIssuerVerification b
 		tokenURL:             p.TokenURL,
 		jwksURL:              p.JWKsURL,
 		userInfoURL:          p.UserInfoURL,
+		endSessionURL:        p.EndSessionURL,
 		codeChallengeAlgs:    p.CodeChallengeAlgs,
 		supportedSigningAlgs: p.SupportedSigningAlgs,
 	}, nil
@@ -80,6 +83,7 @@ type discoveryProvider struct {
 	tokenURL             string
 	jwksURL              string
 	userInfoURL          string
+	endSessionURL        string
 	codeChallengeAlgs    []string
 	supportedSigningAlgs []string
 }
@@ -104,4 +108,9 @@ func (p *discoveryProvider) PKCE() PKCE {
 // SupportedSigningAlgs returns the discovered provider signing algorithms.
 func (p *discoveryProvider) SupportedSigningAlgs() []string {
 	return p.supportedSigningAlgs
+}
+
+// EndSessionURL returns the discovered end_session_endpoint for RP-initiated logout.
+func (p *discoveryProvider) EndSessionURL() string {
+	return p.endSessionURL
 }

--- a/pkg/providers/oidc/provider_test.go
+++ b/pkg/providers/oidc/provider_test.go
@@ -121,6 +121,45 @@ var _ = Describe("Provider", func() {
 
 		Expect(provider.SupportedSigningAlgs()).To(ConsistOf("RS256", "HS256"))
 	})
+
+	It("should extract end_session_endpoint when present in discovery", func() {
+		m, err := mockoidc.NewServer(nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		endSessionURL := "https://idp.example.com/logout"
+		m.AddMiddleware(newEndSessionMiddleware(m, endSessionURL))
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(m.Start(ln, nil)).To(Succeed())
+		defer func() {
+			Expect(m.Shutdown()).To(Succeed())
+		}()
+
+		provider, err := NewProvider(context.Background(), m.Issuer(), false)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(provider.EndSessionURL()).To(Equal(endSessionURL))
+	})
+
+	It("should return empty end_session_endpoint when not present in discovery", func() {
+		m, err := mockoidc.NewServer(nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(m.Start(ln, nil)).To(Succeed())
+		defer func() {
+			Expect(m.Shutdown()).To(Succeed())
+		}()
+
+		provider, err := NewProvider(context.Background(), m.Issuer(), false)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(provider.EndSessionURL()).To(BeEmpty())
+	})
 })
 
 func newInvalidIssuerMiddleware(m *mockoidc.MockOIDC) func(http.Handler) http.Handler {
@@ -172,6 +211,26 @@ func newSigningAlgsIssuerMiddleware(m *mockoidc.MockOIDC) func(http.Handler) htt
 				JWKsURL:              m.JWKSEndpoint(),
 				UserInfoURL:          m.UserinfoEndpoint(),
 				SupportedSigningAlgs: []string{"RS256", "HS256"},
+			}
+			data, err := json.Marshal(p)
+			if err != nil {
+				rw.WriteHeader(500)
+			}
+			rw.Write(data)
+		})
+	}
+}
+
+func newEndSessionMiddleware(m *mockoidc.MockOIDC, endSessionURL string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			p := providerJSON{
+				Issuer:        m.Issuer(),
+				AuthURL:       m.AuthorizationEndpoint(),
+				TokenURL:      m.TokenEndpoint(),
+				JWKsURL:       m.JWKSEndpoint(),
+				UserInfoURL:   m.UserinfoEndpoint(),
+				EndSessionURL: endSessionURL,
 			}
 			data, err := json.Marshal(p)
 			if err != nil {

--- a/providers/openshift.go
+++ b/providers/openshift.go
@@ -457,6 +457,22 @@ func (p *OpenShiftProvider) newOpenShiftClient() (*http.Client, error) {
 	return httpClient, nil
 }
 
+// NewHTTPClient returns a configured HTTP client for making API calls
+// to the OpenShift cluster (e.g. deleting OAuthAccessToken resources).
+func (p *OpenShiftProvider) NewHTTPClient() (*http.Client, error) {
+	base, err := p.newOpenShiftClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// Defensive copy to prevent external mutation of shared cached client state.
+	cloned := *base
+	if tr, ok := base.Transport.(*http.Transport); ok && tr != nil {
+		cloned.Transport = tr.Clone()
+	}
+	return &cloned, nil
+}
+
 // discoverOpenShiftOAuth discovers OAuth endpoints from the well-known endpoint
 func (p *OpenShiftProvider) discoverOpenShiftOAuth(client *http.Client) (*url.URL, *url.URL, error) {
 	wellKnownURL := getKubeAPIURLWithPath(openShiftOAuthDiscoveryPath)

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -86,6 +86,13 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 			providerConfig.ProfileURL = endpoints.UserInfoURL
 			providerConfig.OIDCConfig.JwksURL = endpoints.JWKsURL
 			p.SupportedCodeChallengeMethods = pkce.CodeChallengeAlgs
+
+			if esURL := pv.Provider().EndSessionURL(); esURL != "" {
+				if parsed, err := url.Parse(esURL); err == nil {
+					p.EndSessionURL = parsed
+					logger.Printf("Discovered end_session_endpoint: %s", esURL)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
The sign-out flow only cleared the IdP session for Keycloak because isOIDCProvider() matched on a Keycloak-specific URL pattern and discoverLogoutURL() derived the issuer by stripping Keycloak path segments. For Entra ID (and any non-Keycloak OIDC provider), both checks failed, so sign-out only cleared the local cookie — the user was immediately re-authenticated by the still-active IdP session. Fix by extracting end_session_endpoint during the existing startup OIDC discovery (which already runs for all OIDC providers) and storing it in ProviderData.EndSessionURL. This replaces the lazy runtime discovery with its Keycloak-specific issuer derivation.
- Add end_session_endpoint to OIDC discovery parsing
- Store discovered EndSessionURL in ProviderData at startup
- Simplify isOIDCProvider() to check EndSessionURL != nil
- Remove discoverLogoutURL(), cachedLogoutURL (redundant)
- Add unit tests for discovery, isOIDCProvider, getLogoutURL

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified sign-out flow for more predictable redirects and clearer OIDC vs non‑OIDC behavior.
  * Best-effort OpenShift token cleanup is attempted during sign-out without delaying logout.

* **New Features**
  * OIDC discovery now records the provider end_session_endpoint so IdP logout URLs are honored.

* **Tests**
  * Added coverage for logout behavior, end_session_endpoint discovery, and OpenShift token cleanup.

* **Chores**
  * Minor provider API addition for OpenShift HTTP client exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->