### PR TITLE
fix: provide helpful unauthenticated error message for MLflow SDK users

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -26,6 +26,7 @@ import (
 	sessionsapi "github.com/opendatahub-io/kube-auth-proxy/v1/pkg/apis/sessions"
 	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/app/pagewriter"
 	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/app/redirect"
+	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/authdeny"
 	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/authentication/basic"
 	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/authentication/k8s"
 	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/cookies"
@@ -109,6 +110,7 @@ type OAuthProxy struct {
 	skipJwtBearerTokens  bool
 	forceJSONErrors      bool
 	allowQuerySemicolons bool
+	authDeniedHandlers   []authdeny.Handler
 	realClientIPParser   ipapi.RealClientIPParser
 	trustedIPs           *ip.NetSet
 
@@ -123,6 +125,21 @@ type OAuthProxy struct {
 	appDirector       redirect.AppDirector
 
 	encodeState bool
+}
+
+func (p *OAuthProxy) handleAuthDenied(rw http.ResponseWriter, req *http.Request, statusCode int) bool {
+	// Browser requests should continue through the existing HTML login/error flow.
+	if strings.Contains(req.Header.Get("Accept"), "text/html") {
+		return false
+	}
+
+	for _, handler := range p.authDeniedHandlers {
+		if handler.Handle(rw, req, statusCode) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // NewOAuthProxy creates a new instance of OAuthProxy from the options provided
@@ -246,6 +263,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool, k8sTokenV
 		redirectOnCSRFError:  !opts.DisableRedirectOnCSRFError,
 		forceJSONErrors:      opts.ForceJSONErrors,
 		allowQuerySemicolons: opts.AllowQuerySemicolons,
+		authDeniedHandlers:   []authdeny.Handler{authdeny.NewMLflowHandler()},
 		trustedIPs:           trustedIPs,
 
 		basicAuthValidator: basicAuthValidator,
@@ -1190,6 +1208,9 @@ func (p *OAuthProxy) enrichSessionState(ctx context.Context, s *sessionsapi.Sess
 func (p *OAuthProxy) AuthOnly(rw http.ResponseWriter, req *http.Request) {
 	session, err := p.getAuthenticatedSession(rw, req)
 	if err != nil {
+		if errors.Is(err, ErrNeedsLogin) && p.handleAuthDenied(rw, req, http.StatusUnauthorized) {
+			return
+		}
 		http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
@@ -1197,6 +1218,9 @@ func (p *OAuthProxy) AuthOnly(rw http.ResponseWriter, req *http.Request) {
 	// Unauthorized cases need to return 403 to prevent infinite redirects with
 	// subrequest architectures
 	if !authOnlyAuthorize(req, session) {
+		if p.handleAuthDenied(rw, req, http.StatusForbidden) {
+			return
+		}
 		http.Error(rw, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		return
 	}
@@ -1219,6 +1243,10 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		p.headersChain.Then(p.upstreamProxy).ServeHTTP(rw, req)
 	case ErrNeedsLogin:
 		// we need to send the user to a login screen
+		if p.handleAuthDenied(rw, req, http.StatusUnauthorized) {
+			return
+		}
+
 		if p.forceJSONErrors || isAjax(req) || p.isAPIPath(req) {
 			logger.Printf("No valid authentication in request. Access Denied.")
 			// no point redirecting an AJAX request
@@ -1237,9 +1265,12 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		}
 
 	case ErrAccessDenied:
-		if p.forceJSONErrors {
+		switch {
+		case p.handleAuthDenied(rw, req, http.StatusForbidden):
+			return
+		case p.forceJSONErrors:
 			p.errorJSON(rw, http.StatusForbidden)
-		} else {
+		default:
 			p.ErrorPage(rw, req, http.StatusForbidden, "The session failed authorization checks")
 		}
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -1111,6 +1112,22 @@ func TestAuthOnlyEndpointUnauthorizedOnNoCookieSetError(t *testing.T) {
 	assert.Equal(t, "Unauthorized\n", string(bodyBytes))
 }
 
+func TestAuthOnlyEndpointUnauthorizedMLflowRequest(t *testing.T) {
+	test, err := NewAuthOnlyEndpointTest("")
+	require.NoError(t, err)
+
+	test.req.Header.Set("User-Agent", "mlflow-python-client/3.11.1")
+	test.proxy.ServeHTTP(test.rw, test.req)
+
+	assert.Equal(t, http.StatusUnauthorized, test.rw.Code)
+	assert.Equal(t, applicationJSON, test.rw.Header().Get("Content-Type"))
+
+	var response map[string]string
+	require.NoError(t, json.Unmarshal(test.rw.Body.Bytes(), &response))
+	assert.Equal(t, "UNAUTHENTICATED", response["error_code"])
+	assert.Contains(t, response["message"], "MLFLOW_TRACKING_AUTH=kubernetes-namespaced")
+}
+
 func TestAuthOnlyEndpointUnauthorizedOnExpiration(t *testing.T) {
 	test, err := NewAuthOnlyEndpointTest("", func(opts *options.Options) {
 		opts.Cookie.Expire = time.Duration(24) * time.Hour
@@ -1713,6 +1730,87 @@ func TestAjaxForbiddendRequest(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, code)
 	mime := rh.Get("Content-Type")
 	assert.NotEqual(t, applicationJSON, mime)
+}
+
+func testMLflowUnauthorizedRequest(t *testing.T, header http.Header) {
+	test, err := newAjaxRequestTest(false)
+	require.NoError(t, err)
+
+	code, rh, body, err := test.getEndpoint("/test", header)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, code)
+	assert.Equal(t, applicationJSON, rh.Get("Content-Type"))
+	assert.Empty(t, rh.Get("Location"))
+
+	var response map[string]string
+	require.NoError(t, json.Unmarshal(body, &response))
+	assert.Equal(t, "UNAUTHENTICATED", response["error_code"])
+	assert.Contains(t, response["message"], "`oc login`")
+	assert.Contains(t, response["message"], "`oc project`")
+	assert.Contains(t, response["message"], "MLflow Python client 3.11+")
+	assert.Contains(t, response["message"], "MLFLOW_TRACKING_AUTH=kubernetes-namespaced")
+}
+
+func TestMLflowUnauthorizedRequestUserAgent(t *testing.T) {
+	header := make(http.Header)
+	header.Set("User-Agent", "mlflow-python-client/3.11.1")
+
+	testMLflowUnauthorizedRequest(t, header)
+}
+
+func TestMLflowUserAgentBrowserRequestFallsBackToSignInPage(t *testing.T) {
+	test, err := newAjaxRequestTest(false)
+	require.NoError(t, err)
+
+	header := make(http.Header)
+	header.Set("Accept", "text/html")
+	header.Set("User-Agent", "mlflow-python-client/3.11.1")
+
+	code, rh, body, err := test.getEndpoint("/test", header)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, code)
+	assert.NotEqual(t, applicationJSON, rh.Get("Content-Type"))
+	assert.NotContains(t, string(body), "MLFLOW_TRACKING_AUTH=kubernetes-namespaced")
+}
+
+func TestMLflowAccessDeniedFallsBackToDefaultResponse(t *testing.T) {
+	opts := baseTestOptions()
+	err := validation.Validate(opts)
+	require.NoError(t, err)
+
+	proxy, err := NewOAuthProxy(opts, func(email string) bool {
+		return email == "allowed@example.com"
+	}, nil)
+	require.NoError(t, err)
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err = proxy.sessionStore.Save(rw, req, &sessions.SessionState{
+		Email: "denied@example.com",
+	})
+	require.NoError(t, err)
+
+	req = httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Cookie", rw.Header().Values("Set-Cookie")[0])
+	req.Header.Set("User-Agent", "mlflow-python-client/3.11.1")
+
+	rw = httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusForbidden, rw.Code)
+	assert.NotEqual(t, applicationJSON, rw.Header().Get("Content-Type"))
+	assert.NotContains(t, rw.Body.String(), "MLFLOW_TRACKING_AUTH=kubernetes-namespaced")
+}
+
+func TestNonMLflowRequestStillUsesSignInPage(t *testing.T) {
+	test, err := newAjaxRequestTest(false)
+	require.NoError(t, err)
+
+	code, rh, body, err := test.getEndpoint("/test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, code)
+	assert.NotEqual(t, applicationJSON, rh.Get("Content-Type"))
+	assert.NotContains(t, string(body), "MLFLOW_TRACKING_AUTH=kubernetes-namespaced")
 }
 
 func TestClearSplitCookie(t *testing.T) {

--- a/pkg/authdeny/handler.go
+++ b/pkg/authdeny/handler.go
@@ -1,0 +1,11 @@
+package authdeny
+
+import "net/http"
+
+// Handler can override the default denial response for matched requests.
+// Returning true means the handler wrote the complete response and the caller
+// must stop. Returning false means the caller should continue with the
+// existing fallback behavior.
+type Handler interface {
+	Handle(rw http.ResponseWriter, req *http.Request, statusCode int) bool
+}

--- a/pkg/authdeny/mlflow.go
+++ b/pkg/authdeny/mlflow.go
@@ -1,0 +1,57 @@
+package authdeny
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/opendatahub-io/kube-auth-proxy/v1/pkg/logger"
+)
+
+const (
+	applicationJSON              = "application/json"
+	mlflowClientUserAgentPrefix  = "mlflow-python-client/"
+	mlflowUnauthenticatedMessage = "Authentication to the MLflow tracking server failed. " +
+		"Ensure you are logged in to the OpenShift cluster with `oc login`, have selected the " +
+		"correct project/MLflow workspace with `oc project`, are using MLflow Python " +
+		"client 3.11+, and have set MLFLOW_TRACKING_AUTH=kubernetes-namespaced to " +
+		"automatically use your OpenShift credentials."
+)
+
+type mlflowHandler struct{}
+
+func NewMLflowHandler() Handler {
+	return mlflowHandler{}
+}
+
+func (mlflowHandler) Handle(rw http.ResponseWriter, req *http.Request, statusCode int) bool {
+	if !strings.HasPrefix(req.Header.Get("User-Agent"), mlflowClientUserAgentPrefix) {
+		return false
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized:
+		logger.Printf("No valid authentication in MLflow SDK request. Access Denied.")
+		writeErrorJSON(rw, statusCode, "UNAUTHENTICATED", mlflowUnauthenticatedMessage)
+		return true
+	default:
+		return false
+	}
+}
+
+func writeErrorJSON(rw http.ResponseWriter, code int, errorCode string, message string) {
+	rw.Header().Set("Content-Type", applicationJSON)
+	rw.WriteHeader(code)
+
+	if errorCode == "" && message == "" {
+		// We need to send some JSON response because we set the Content-Type to
+		// application/json.
+		_, _ = rw.Write([]byte("{}"))
+		return
+	}
+
+	_ = json.NewEncoder(rw).Encode(map[string]string{
+		"error_code": errorCode,
+		"message":    message,
+	})
+}


### PR DESCRIPTION
## Description

The MLflow SDK expects a JSON error message, so when the user omits a token or puts an invalid one, kube-auth-proxy redirects to the OAuth login page which causes a hard to understand error message for the user.

This provides a generic way for kube-auth-proxy to allow custom error messages based on the user agent/headers.

https://redhat.atlassian.net/browse/RHOAIENG-61102

## Motivation and Context

ODH/RHOAI users would not get a clear message when their authentication configuration was not properly set in the MLflow Python client. The MLflow Python client is the primary way to send logged metrics and LLM traces to MLflow.

This the experience prior:

```
❯ MLFLOW_TRACKING_URI="https://data-science-gateway.apps.rosa.mprahl2.otuf.p3.openshiftapps.com/mlflow" python -c "import mlflow; print(mlflow.list_workspaces())"
2026/05/18 14:58:06 WARNING mlflow.utils.rest_utils: Response is not a valid JSON object: <!DOCTYPE html>
<html lang="en-us" data-test-id="l...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/fluent.py", line 58, in list_workspaces
    return _workspace_client_call(lambda client: client.list_workspaces())
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/fluent.py", line 28, in _workspace_client_call
    return func(client)
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/fluent.py", line 58, in <lambda>
    return _workspace_client_call(lambda client: client.list_workspaces())
  File "/home/mprahl/git/mlflow/mlflow/tracking/client.py", line 335, in list_workspaces
    return self._get_workspace_client().list_workspaces()
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/client.py", line 42, in list_workspaces
    return list(self.store.list_workspaces())
  File "/home/mprahl/git/mlflow/mlflow/store/workspace/rest_store.py", line 46, in list_workspaces
    proto = call_endpoint(
  File "/home/mprahl/git/mlflow/mlflow/utils/rest_utils.py", line 670, in call_endpoint
    js_dict = json.loads(response_to_parse)
  File "/usr/lib64/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## How Has This Been Tested?

I manually deployed the ODH operator PR here to forward the user-agent header:
https://github.com/opendatahub-io/opendatahub-operator/pull/3557

I also deployed this PR on my cluster and tested with MLflow:

```bash
❯ MLFLOW_TRACKING_URI="https://data-science-gateway.apps.rosa.mprahl2.otuf.p3.openshiftapps.com/mlflow" python -c "import mlflow; print(mlflow.list_workspaces())"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/fluent.py", line 58, in list_workspaces
    return _workspace_client_call(lambda client: client.list_workspaces())
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/fluent.py", line 28, in _workspace_client_call
    return func(client)
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/fluent.py", line 58, in <lambda>
    return _workspace_client_call(lambda client: client.list_workspaces())
  File "/home/mprahl/git/mlflow/mlflow/tracking/client.py", line 335, in list_workspaces
    return self._get_workspace_client().list_workspaces()
  File "/home/mprahl/git/mlflow/mlflow/tracking/_workspace/client.py", line 42, in list_workspaces
    return list(self.store.list_workspaces())
  File "/home/mprahl/git/mlflow/mlflow/store/workspace/rest_store.py", line 46, in list_workspaces
    proto = call_endpoint(
  File "/home/mprahl/git/mlflow/mlflow/utils/rest_utils.py", line 660, in call_endpoint
    response = verify_rest_response(
  File "/home/mprahl/git/mlflow/mlflow/utils/rest_utils.py", line 367, in verify_rest_response
    raise RestException(json.loads(response.text))
mlflow.exceptions.RestException: UNAUTHENTICATED: Authentication to the MLflow tracking server failed. Ensure you are logged in to the cluster with `oc login`, have selected the correct project/MLflow workspace with `oc project`, are using MLflow SDK 3.11+, and have set MLFLOW_TRACKING_AUTH=kubernetes-namespaced to automatically use your OpenShift credentials.
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable auth-denial handlers to customize responses on 401/403, including a new MLflow-specific handler that returns JSON guidance for MLflow Python client auth failures.
* **Tests**
  * Added tests validating MLflow-specific unauthorized/forbidden JSON responses and ensuring non-MLflow/browser requests continue to show existing sign-in/error-page behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->