### PR TITLE
feat: set NextProtos on upstream proxy TLS client transport

### DIFF
--- a/kube-rbac-proxy/cmd/kube-rbac-proxy/app/transport.go
+++ b/kube-rbac-proxy/cmd/kube-rbac-proxy/app/transport.go
@@ -30,6 +30,10 @@ func initTransport(upstreamCAPool *x509.CertPool, upstreamClientCertPath, upstre
 		// Create transport based on DefaultTransport for timeout support
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.ResponseHeaderTimeout = timeout
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.NextProtos = []string{"h2", "http/1.1"}
 		return transport, nil
 
 	}
@@ -60,6 +64,8 @@ func initTransport(upstreamCAPool *x509.CertPool, upstreamClientCertPath, upstre
 			RootCAs: upstreamCAPool,
 		},
 	}
+
+	transport.TLSClientConfig.NextProtos = []string{"h2", "http/1.1"}
 
 	if certKeyPair.Certificate != nil {
 		transport.TLSClientConfig.Certificates = []tls.Certificate{certKeyPair}

--- a/kube-rbac-proxy/cmd/kube-rbac-proxy/app/transport.go
+++ b/kube-rbac-proxy/cmd/kube-rbac-proxy/app/transport.go
@@ -51,7 +51,8 @@ func initTransport(upstreamCAPool *x509.CertPool, upstreamClientCertPath, upstre
 
 	// http.Transport sourced from go 1.10.7
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		ForceAttemptHTTP2: true,
+		Proxy:             http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/kube-rbac-proxy/cmd/kube-rbac-proxy/app/transport.go
+++ b/kube-rbac-proxy/cmd/kube-rbac-proxy/app/transport.go
@@ -31,7 +31,9 @@ func initTransport(upstreamCAPool *x509.CertPool, upstreamClientCertPath, upstre
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.ResponseHeaderTimeout = timeout
 		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = &tls.Config{}
+			transport.TLSClientConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
 		}
 		transport.TLSClientConfig.NextProtos = []string{"h2", "http/1.1"}
 		return transport, nil
@@ -61,7 +63,8 @@ func initTransport(upstreamCAPool *x509.CertPool, upstreamClientCertPath, upstre
 		ExpectContinueTimeout: 1 * time.Second,
 		ResponseHeaderTimeout: timeout,
 		TLSClientConfig: &tls.Config{
-			RootCAs: upstreamCAPool,
+			RootCAs:    upstreamCAPool,
+			MinVersion: tls.VersionTLS12,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Adds ALPN negotiation (`h2`, `http/1.1`) to the TLS client config used for proxying requests to upstream services
- Without explicit `NextProtos`, Go's TLS client does not advertise protocol preferences during the TLS handshake, which can cause protocol mismatches with servers that require ALPN

## Details

Sets `transport.TLSClientConfig.NextProtos = []string{"h2", "http/1.1"}` on the upstream proxy transport after the `TLSClientConfig` is initialized.

Ref: [RHOAIENG-61401](https://redhat.atlassian.net/browse/RHOAIENG-61401)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upstream TLS protocol negotiation by explicitly enabling both HTTP/2 and HTTP/1.1 for upstream connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->