### PR TITLE
Update Dockerfile.redhat Go version to 1.26

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -8,7 +8,7 @@ ARG VERSION
 # For FIPS builds with CGO, we must build on the native target platform
 # because cross-compilation with CGO requires cross-compiler toolchains
 # which are not readily available in the UBI base images.
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # Switch to root for build permissions
 USER root


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates kube-auth-proxy's Dockerfile.redhat to use Go 1.26.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Initially was included within https://github.com/opendatahub-io/kube-auth-proxy/pull/90 to update the Go version, however this specific change on it's own was separated as it would make it easier to determine any potential problems.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Builds without issues.
Tests pass without issue or error.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
