### PR TITLE
fix: sanitize TokenReview errors to prevent token-fragment leaks in logs

### DIFF
--- a/pkg/authentication/k8s/tokenreview.go
+++ b/pkg/authentication/k8s/tokenreview.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -85,12 +86,12 @@ func (v *TokenReviewValidator) ValidateToken(ctx context.Context, token string) 
 
 	result, err := v.client.AuthenticationV1().TokenReviews().Create(ctx, tr, metav1.CreateOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("TokenReview API call failed: %w", sanitizeTokenReviewError(err))
 	}
 
 	if !result.Status.Authenticated {
 		if result.Status.Error != "" {
-			return nil, fmt.Errorf("token not authenticated by TokenReview API: %s", result.Status.Error)
+			return nil, fmt.Errorf("token not authenticated by TokenReview API: %s", sanitizeStatusError(result.Status.Error))
 		}
 		return nil, errors.New("token not authenticated by TokenReview API")
 	}
@@ -111,4 +112,27 @@ func (v *TokenReviewValidator) ValidateToken(ctx context.Context, token string) 
 	session.SetExpiresOn(session.Clock.Now().Add(30 * time.Second))
 
 	return session, nil
+}
+
+// Patterns for redacting token fragments from error messages.
+const (
+	jwtTokenPattern   = `eyJ[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*` //nosec G101 -- regex for redaction, not a credential
+	oauthTokenPattern = `sha256~[a-zA-Z0-9_-]+` //nosec G101 -- regex for redaction, not a credential
+)
+
+// tokenPatterns is a compiled regex that matches JWT or OpenShift OAuth token fragments.
+var tokenPatterns = regexp.MustCompile(jwtTokenPattern + `|` + oauthTokenPattern)
+
+// sanitizeTokenReviewError removes potential token fragments from Kubernetes API errors.
+// The client-go library may include request/response details that contain token material.
+func sanitizeTokenReviewError(err error) error {
+	cleaned := tokenPatterns.ReplaceAllString(err.Error(), "[REDACTED]")
+	return errors.New(cleaned)
+}
+
+// sanitizeStatusError removes potential token fragments from the TokenReview Status.Error field.
+// While the API server typically returns messages like "token expired", some implementations
+// may echo back token fragments.
+func sanitizeStatusError(statusErr string) string {
+	return tokenPatterns.ReplaceAllString(statusErr, "[REDACTED]")
 }

--- a/pkg/authentication/k8s/tokenreview_test.go
+++ b/pkg/authentication/k8s/tokenreview_test.go
@@ -167,7 +167,7 @@ func TestTokenReviewValidator_ValidateToken_APIError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, session)
-	assert.Contains(t, err.Error(), "connection refused")
+	assert.Contains(t, err.Error(), "TokenReview API call failed")
 }
 
 func TestTokenReviewValidator_ValidateToken_AudienceValidation(t *testing.T) {
@@ -269,4 +269,81 @@ func TestTokenReviewValidator_ValidateToken_SessionFields(t *testing.T) {
 	assert.False(t, session.CreatedAt.IsZero())
 	assert.True(t, session.ExpiresOn.After(time.Now()))
 	assert.True(t, session.ExpiresOn.Before(time.Now().Add(25*time.Hour)))
+}
+
+func TestTokenReviewValidator_ValidateToken_ErrorSanitization(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiError    error
+		statusError string
+		expected    string
+	}{
+		{
+			name:     "API error with JWT-like fragment is redacted",
+			apiError: errors.New("failed to validate token eyJhbGciOiJSUzI1Ni.eyJpc3MiOiJrdWJlcm5ldGVz: connection timeout"),
+			expected: "TokenReview API call failed: failed to validate token [REDACTED]: connection timeout",
+		},
+		{
+			name:        "status error with token fragment is redacted",
+			statusError: "token eyJhbGciOiJSUzI1Ni.eyJpc3MiOiJrdWJlcm5ldGVz is expired",
+			expected:    "token not authenticated by TokenReview API: token [REDACTED] is expired",
+		},
+		{
+			name:     "API error with OpenShift sha256 token is redacted",
+			apiError: errors.New("invalid token: sha256~abcdefghijklmnopqrstuvwxyz123456 not found"),
+			expected: "TokenReview API call failed: invalid token: [REDACTED] not found",
+		},
+		{
+			name:     "simple error messages pass through unchanged",
+			apiError: errors.New("connection refused"),
+			expected: "TokenReview API call failed: connection refused",
+		},
+		{
+			name:        "simple status error passes through unchanged",
+			statusError: "token has expired",
+			expected:    "token not authenticated by TokenReview API: token has expired",
+		},
+		{
+			name:     "short dotted strings are not redacted",
+			apiError: errors.New("dial tcp api.cluster.local:6443: connection refused"),
+			expected: "TokenReview API call failed: dial tcp api.cluster.local:6443: connection refused",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mockFunc func(ctx context.Context, tr *authenticationv1.TokenReview, opts metav1.CreateOptions) (*authenticationv1.TokenReview, error)
+
+			if tt.apiError != nil {
+				mockFunc = func(ctx context.Context, tr *authenticationv1.TokenReview, opts metav1.CreateOptions) (*authenticationv1.TokenReview, error) {
+					return nil, tt.apiError
+				}
+			} else {
+				mockFunc = func(ctx context.Context, tr *authenticationv1.TokenReview, opts metav1.CreateOptions) (*authenticationv1.TokenReview, error) {
+					return &authenticationv1.TokenReview{
+						Status: authenticationv1.TokenReviewStatus{
+							Authenticated: false,
+							Error:         tt.statusError,
+						},
+					}, nil
+				}
+			}
+
+			client := &mockKubernetesClient{
+				Interface: fake.NewSimpleClientset(),
+				authClient: &mockTokenReviewClient{
+					tokenReviewFunc: mockFunc,
+				},
+			}
+
+			validator := &TokenReviewValidator{
+				client:    client,
+				audiences: []string{"test-audience"},
+			}
+
+			_, err := validator.ValidateToken(context.Background(), "test-token")
+			assert.Error(t, err)
+			assert.Equal(t, tt.expected, err.Error())
+		})
+	}
 }

--- a/pkg/middleware/k8s_token_session.go
+++ b/pkg/middleware/k8s_token_session.go
@@ -62,7 +62,7 @@ func (l *k8sTokenSessionLoader) loadSession(next http.Handler) http.Handler {
 			// TokenReview validation failed
 			// Don't return error - this might be an OIDC token or OpenShift OAuth token
 			// Let the next handler in the chain try to validate it
-			logger.Errorf("K8s TokenReview validation failed: %v", err)
+			logger.Printf("K8s TokenReview validation failed: %v", err)
 			next.ServeHTTP(rw, req)
 			return
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling by redacting sensitive token-like fragments in validation and status failure messages.
  * Sanitized Kubernetes TokenReview-related error text to avoid exposing token fragments in logs or UI-facing output.
  * Reduced the severity of a token validation failure log entry while keeping the request flow the same.
* **Tests**
  * Expanded test coverage to verify redaction across multiple error formats and ensure non-sensitive messages remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->