### PR TITLE
fix: increase Konflux wait timeout to 60 minutes in tag-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g. v3.5.0-ea.2)'
+        description: 'Release version (e.g. v3.5.0 or v3.5.0-ea.2)'
         required: true
 
 permissions:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -57,25 +57,37 @@ jobs:
         REPO: ${{ github.repository }}
       run: |
         SHA=$(git rev-parse HEAD)
+        KONFLUX_CHECK="Red Hat Konflux / kube-auth-proxy-on-push"
         echo "Waiting for Konflux check on commit ${SHA}..."
 
-        for i in $(seq 1 60); do
-          STATUS=$(gh api repos/${REPO}/commits/${SHA}/check-runs \
-            --jq '.check_runs[] | select(.name == "Red Hat Konflux / kube-auth-proxy-on-push") | .conclusion' 2>/dev/null || echo "")
+        KONFLUX_URL=""
+        for i in $(seq 1 120); do
+          RESULT=$(gh api repos/${REPO}/commits/${SHA}/check-runs \
+            --jq ".check_runs[] | select(.name == \"${KONFLUX_CHECK}\") | {conclusion, details_url}" 2>/dev/null || echo "")
 
-          if [ "$STATUS" = "success" ]; then
-            echo "Konflux build passed"
-            exit 0
-          elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "cancelled" ]; then
-            echo "::error::Konflux build failed with status: ${STATUS}"
-            exit 1
+          if [ -n "$RESULT" ]; then
+            STATUS=$(echo "$RESULT" | jq -r '.conclusion // empty')
+            if [ -z "$KONFLUX_URL" ]; then
+              KONFLUX_URL=$(echo "$RESULT" | jq -r '.details_url // empty')
+              if [ -n "$KONFLUX_URL" ]; then
+                echo "::notice::Konflux pipeline: ${KONFLUX_URL}"
+              fi
+            fi
+
+            if [ "$STATUS" = "success" ]; then
+              echo "Konflux build passed"
+              exit 0
+            elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "cancelled" ]; then
+              echo "::error::Konflux build failed (status: ${STATUS}). See: ${KONFLUX_URL}"
+              exit 1
+            fi
           fi
 
-          echo "Attempt ${i}/60: Konflux build still running, waiting 30s..."
+          echo "Attempt ${i}/120: Konflux build still running, waiting 30s..."
           sleep 30
         done
 
-        echo "::error::Timed out waiting for Konflux build (30 minutes)"
+        echo "::error::Timed out waiting for Konflux build (60 minutes)"
         exit 1
 
     - name: Detect previous tag


### PR DESCRIPTION
Konflux builds can take 50+ minutes when queued in Kueue, causing the 30-minute timeout to expire before the build completes.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
